### PR TITLE
Add match expressions to the CST

### DIFF
--- a/crates/ditto-ast/src/expression.rs
+++ b/crates/ditto-ast/src/expression.rs
@@ -58,6 +58,25 @@ pub enum Expression {
         /// The expression to evaluate otherwise.
         false_clause: Box<Self>,
     },
+    /// A pattern match.
+    ///
+    /// ```ditto
+    /// match some_expr with
+    /// | Pattern -> another_expr
+    /// ```
+    Match {
+        /// The source span for this expression.
+        span: Span,
+
+        /// The type of the expressions in the `arms`.
+        match_type: Type,
+
+        /// Expression to be matched.
+        expression: Box<Self>,
+
+        /// Patterns to be matched against and their corresponding expressions.
+        arms: NonEmpty<(Pattern, Self)>,
+    },
     /// A value constructor local to the current module, e.g. `Just` and `Ok`.
     LocalConstructor {
         /// The source span for this expression.
@@ -193,6 +212,7 @@ impl Expression {
                 }
             }
             Self::If { output_type, .. } => output_type.clone(),
+            Self::Match { match_type, .. } => match_type.clone(),
             Self::LocalConstructor {
                 constructor_type, ..
             } => constructor_type.clone(),
@@ -220,6 +240,7 @@ impl Expression {
             Self::Function { span, .. } => *span,
             Self::Call { span, .. } => *span,
             Self::If { span, .. } => *span,
+            Self::Match { span, .. } => *span,
             Self::LocalConstructor { span, .. } => *span,
             Self::ImportedConstructor { span, .. } => *span,
             Self::LocalVariable { span, .. } => *span,
@@ -295,4 +316,34 @@ impl FunctionBinder {
             Self::Name { span, .. } => *span,
         }
     }
+}
+
+/// A pattern to be matched.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Pattern {
+    /// A local constructor pattern.
+    LocalConstructor {
+        /// The source span for this pattern.
+        span: Span,
+        /// `Just`
+        constructor: ProperName,
+        /// Pattern arguments to the constructor.
+        arguments: Vec<Self>,
+    },
+    /// An importedf constructor pattern.
+    ImportedConstructor {
+        /// The source span for this pattern.
+        span: Span,
+        /// `Maybe.Just`
+        constructor: FullyQualifiedProperName,
+        /// Pattern arguments to the constructor.
+        arguments: Vec<Self>,
+    },
+    /// A variable binding pattern.
+    Variable {
+        /// The source span for this pattern.
+        span: Span,
+        /// Name to bind.
+        name: Name,
+    },
 }

--- a/crates/ditto-checker/golden-tests/type-errors/match_unification_error_0.ditto
+++ b/crates/ditto-checker/golden-tests/type-errors/match_unification_error_0.ditto
@@ -1,0 +1,8 @@
+module Test exports (..);
+
+type Foo = Foo;
+type Bar = Bar;
+
+nah = 
+  match Foo with
+  | Bar -> unit;

--- a/crates/ditto-checker/golden-tests/type-errors/match_unification_error_0.error
+++ b/crates/ditto-checker/golden-tests/type-errors/match_unification_error_0.error
@@ -1,0 +1,12 @@
+
+  × types don't unify
+   ╭─[golden:5:1]
+ 5 │ 
+ 6 │ nah = 
+ 7 │   match Foo with
+ 8 │   | Bar -> unit;
+   ·     ─┬─
+   ·      ╰── here
+   ╰────
+  help: expected Foo
+        got Bar

--- a/crates/ditto-checker/golden-tests/type-errors/match_unification_error_1.ditto
+++ b/crates/ditto-checker/golden-tests/type-errors/match_unification_error_1.ditto
@@ -1,0 +1,10 @@
+module Test exports (..);
+
+type Maybe(a) = Just(a) | Nothing;
+type Foo = Foo;
+type Bar = Bar;
+
+nah = (maybe_foo : Maybe(Foo)) -> 
+  match maybe_foo with
+  | Just(Bar) -> unit
+  | Nothing -> unit;

--- a/crates/ditto-checker/golden-tests/type-errors/match_unification_error_1.error
+++ b/crates/ditto-checker/golden-tests/type-errors/match_unification_error_1.error
@@ -1,0 +1,13 @@
+
+  × types don't unify
+    ╭─[golden:6:1]
+  6 │ 
+  7 │ nah = (maybe_foo : Maybe(Foo)) -> 
+  8 │   match maybe_foo with
+  9 │   | Just(Bar) -> unit
+    ·          ─┬─
+    ·           ╰── here
+ 10 │   | Nothing -> unit;
+    ╰────
+  help: expected Foo
+        got Bar

--- a/crates/ditto-checker/golden-tests/type-errors/match_unification_error_2.ditto
+++ b/crates/ditto-checker/golden-tests/type-errors/match_unification_error_2.ditto
@@ -1,0 +1,8 @@
+module Test exports (..);
+
+type Maybe(a) = Just(a) | Nothing;
+
+nah = (maybe_foo : Maybe(Int)) -> 
+  match maybe_foo with
+  | Just(a, b) -> unit
+  | Nothing -> unit;

--- a/crates/ditto-checker/golden-tests/type-errors/match_unification_error_2.error
+++ b/crates/ditto-checker/golden-tests/type-errors/match_unification_error_2.error
@@ -1,0 +1,11 @@
+
+  × wrong number of arguments
+   ╭─[golden:4:1]
+ 4 │ 
+ 5 │ nah = (maybe_foo : Maybe(Int)) -> 
+ 6 │   match maybe_foo with
+ 7 │   | Just(a, b) -> unit
+   ·     ─────┬────
+   ·          ╰── this expects 1 argument
+ 8 │   | Nothing -> unit;
+   ╰────

--- a/crates/ditto-checker/golden-tests/type-errors/match_unification_error_3.ditto
+++ b/crates/ditto-checker/golden-tests/type-errors/match_unification_error_3.ditto
@@ -1,0 +1,8 @@
+module Test exports (..);
+
+type Maybe(a) = Just(a) | Nothing;
+
+nah = (maybe_foo : Maybe(Int)) -> 
+  match maybe_foo with
+  | Just -> unit
+  | Nothing -> unit;

--- a/crates/ditto-checker/golden-tests/type-errors/match_unification_error_3.error
+++ b/crates/ditto-checker/golden-tests/type-errors/match_unification_error_3.error
@@ -1,0 +1,11 @@
+
+  × wrong number of arguments
+   ╭─[golden:4:1]
+ 4 │ 
+ 5 │ nah = (maybe_foo : Maybe(Int)) -> 
+ 6 │   match maybe_foo with
+ 7 │   | Just -> unit
+   ·     ──┬─
+   ·       ╰── this expects 1 argument
+ 8 │   | Nothing -> unit;
+   ╰────

--- a/crates/ditto-checker/golden-tests/type-errors/match_unification_error_4.ditto
+++ b/crates/ditto-checker/golden-tests/type-errors/match_unification_error_4.ditto
@@ -1,0 +1,8 @@
+module Test exports (..);
+
+type Maybe(a) = Just(a) | Nothing;
+
+nah = (maybe_foo : Maybe(Int)) -> 
+  match maybe_foo with
+  | Just(n) -> unit
+  | Nothing(a) -> unit;

--- a/crates/ditto-checker/golden-tests/type-errors/match_unification_error_4.error
+++ b/crates/ditto-checker/golden-tests/type-errors/match_unification_error_4.error
@@ -1,0 +1,10 @@
+
+  × wrong number of arguments
+   ╭─[golden:5:1]
+ 5 │ nah = (maybe_foo : Maybe(Int)) -> 
+ 6 │   match maybe_foo with
+ 7 │   | Just(n) -> unit
+ 8 │   | Nothing(a) -> unit;
+   ·     ─────┬────
+   ·          ╰── this expects no arguments
+   ╰────

--- a/crates/ditto-checker/golden-tests/type-errors/match_unification_error_5.ditto
+++ b/crates/ditto-checker/golden-tests/type-errors/match_unification_error_5.ditto
@@ -1,0 +1,8 @@
+module Test exports (..);
+
+type Maybe(a) = Just(a) | Nothing;
+
+nah = (maybe_foo : Maybe(Int)): Int -> 
+  match maybe_foo with
+  | Just(n) -> unit
+  | Nothing -> unit;

--- a/crates/ditto-checker/golden-tests/type-errors/match_unification_error_5.error
+++ b/crates/ditto-checker/golden-tests/type-errors/match_unification_error_5.error
@@ -1,0 +1,13 @@
+
+  × types don't unify
+   ╭─[golden:4:1]
+ 4 │ 
+ 5 │ nah = (maybe_foo : Maybe(Int)): Int -> 
+ 6 │   match maybe_foo with
+ 7 │   | Just(n) -> unit
+   ·                ──┬─
+   ·                  ╰── here
+ 8 │   | Nothing -> unit;
+   ╰────
+  help: expected Int
+        got Unit

--- a/crates/ditto-checker/src/module/value_declarations/mod.rs
+++ b/crates/ditto-checker/src/module/value_declarations/mod.rs
@@ -455,6 +455,18 @@ fn toposort_value_declarations(
                 get_connected_nodes_rec(true_clause, nodes, accum);
                 get_connected_nodes_rec(false_clause, nodes, accum);
             }
+            Expression::Match {
+                expression,
+                head_arm,
+                tail_arms,
+                ..
+            } => {
+                get_connected_nodes_rec(expression, nodes, accum);
+                get_connected_nodes_rec(&head_arm.expression, nodes, accum);
+                for tail_arm in tail_arms.iter() {
+                    get_connected_nodes_rec(&tail_arm.expression, nodes, accum);
+                }
+            }
             Expression::Array(elements) => {
                 if let Some(ref elements) = elements.value {
                     elements.iter().for_each(|element| {

--- a/crates/ditto-checker/src/typechecker/env.rs
+++ b/crates/ditto-checker/src/typechecker/env.rs
@@ -1,15 +1,15 @@
 use super::{common::type_variables, Scheme};
 use crate::supply::Supply;
 use ditto_ast::{
-    Expression, FullyQualifiedName, FullyQualifiedProperName, Name, ProperName, QualifiedName,
-    QualifiedProperName, Span, Type,
+    Expression, FullyQualifiedName, FullyQualifiedProperName, Name, Pattern, ProperName,
+    QualifiedName, QualifiedProperName, Span, Type,
 };
 use std::{
     collections::{HashMap, HashSet},
     default::Default,
 };
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Env {
     pub constructors: EnvConstructors,
     pub values: EnvValues,
@@ -155,6 +155,26 @@ impl EnvConstructor {
                 }
             }
         }
+    }
+
+    // REVIEW should this be `into_pattern`?
+    pub fn to_pattern(&self, span: Span, arguments: Vec<Pattern>) -> Pattern {
+        match self {
+            Self::ModuleConstructor { constructor, .. } => Pattern::LocalConstructor {
+                span,
+                constructor: constructor.clone(),
+                arguments,
+            },
+            Self::ImportedConstructor { constructor, .. } => Pattern::ImportedConstructor {
+                span,
+                constructor: constructor.clone(),
+                arguments,
+            },
+        }
+    }
+
+    pub fn get_type(&self, supply: &mut Supply) -> Type {
+        self.get_scheme().instantiate(supply)
     }
 
     fn get_scheme(&self) -> Scheme {

--- a/crates/ditto-checker/src/typechecker/substitution.rs
+++ b/crates/ditto-checker/src/typechecker/substitution.rs
@@ -126,6 +126,23 @@ impl Substitution {
                 true_clause: Box::new(self.apply_expression(true_clause)),
                 false_clause: Box::new(self.apply_expression(false_clause)),
             },
+            Match {
+                span,
+                match_type,
+                box expression,
+                arms,
+            } => Match {
+                span,
+                match_type: self.apply(match_type),
+                expression: Box::new(self.apply_expression(expression)),
+                arms: unsafe {
+                    NonEmpty::new_unchecked(
+                        arms.into_iter()
+                            .map(|(pattern, expr)| (pattern, self.apply_expression(expr)))
+                            .collect(),
+                    )
+                },
+            },
             LocalConstructor {
                 constructor_type,
                 span,

--- a/crates/ditto-checker/src/typechecker/tests/match.rs
+++ b/crates/ditto-checker/src/typechecker/tests/match.rs
@@ -1,0 +1,17 @@
+use super::macros::*;
+use crate::TypeError::*;
+
+#[test]
+fn it_typechecks_as_expected() {
+    assert_type!(r#" match 5 with | x -> 2.0  "#, "Float");
+    assert_type!(r#" match true with | x -> x "#, "Bool");
+    assert_type!(r#" match true with | x -> unit | y -> unit "#, "Unit");
+}
+
+#[test]
+fn it_errors_as_expected() {
+    assert_type_error!(
+        r#" match 5 with | x -> unit | y -> true "#,
+        TypesNotEqual { .. }
+    );
+}

--- a/crates/ditto-checker/src/typechecker/tests/mod.rs
+++ b/crates/ditto-checker/src/typechecker/tests/mod.rs
@@ -6,5 +6,6 @@ mod float;
 mod function;
 mod int;
 pub(self) mod macros;
+mod r#match;
 mod string;
 mod unit;

--- a/crates/ditto-codegen-js/golden-tests/javascript/match_expressions.ditto
+++ b/crates/ditto-codegen-js/golden-tests/javascript/match_expressions.ditto
@@ -1,0 +1,9 @@
+module Test exports (..);
+
+type Maybe(a) = Just(a) | Nothing;
+
+
+with_default = (maybe: Maybe(a), default: a): a ->
+    match maybe with
+    | Just(a) -> a
+    | Nothing -> default;

--- a/crates/ditto-codegen-js/golden-tests/javascript/match_expressions.js
+++ b/crates/ditto-codegen-js/golden-tests/javascript/match_expressions.js
@@ -1,0 +1,17 @@
+function Just($0) {
+  return ["Just", $0];
+}
+const Nothing = ["Nothing"];
+function withDefault(maybe, $default) {
+  return maybe[0] === "Nothing"
+    ? $default
+    : maybe[0] === "Just"
+    ? (() => {
+        const a = maybe[1];
+        return a;
+      })()
+    : (() => {
+        throw new Error("Pattern match error");
+      })();
+}
+export { Just, Nothing, withDefault };

--- a/crates/ditto-codegen-js/src/ast.rs
+++ b/crates/ditto-codegen-js/src/ast.rs
@@ -46,16 +46,26 @@ pub enum ModuleStatement {
 }
 
 /// A bunch of statements surrounded by braces.
+#[derive(Clone)]
 pub struct Block(pub Vec<BlockStatement>);
 
 /// A single JavaScript statement.
 ///
 /// These end with a semicolon.
+#[derive(Clone)]
 pub enum BlockStatement {
     /// ```javascript
     /// const ident = expression;
     /// ```
-    _ConstAssignment { ident: Ident, value: Expression },
+    ConstAssignment { ident: Ident, value: Expression },
+    /// ```javascript
+    /// console.log("hi");
+    /// ```
+    _Expression(Expression),
+    /// ```javascript
+    /// throw new Error("message")
+    /// ```
+    Throw(String),
     /// ```javascript
     /// return bar;
     /// return;
@@ -63,6 +73,7 @@ pub enum BlockStatement {
     Return(Option<Expression>),
 }
 
+#[derive(Clone)]
 pub enum Expression {
     /// `true`
     True,
@@ -86,22 +97,22 @@ pub enum Expression {
     /// function(argument, argument, argument)
     /// ```
     Call {
-        function: Box<Expression>,
-        arguments: Vec<Expression>,
+        function: Box<Self>,
+        arguments: Vec<Self>,
     },
     /// ```javascript
     /// condition ? true_clause : false_clause
     /// ```
     Conditional {
-        condition: Box<Expression>,
-        true_clause: Box<Expression>,
-        false_clause: Box<Expression>,
+        condition: Box<Self>,
+        true_clause: Box<Self>,
+        false_clause: Box<Self>,
     },
     /// ```javascript
     /// []
     /// [5, 5, 5]
     /// ```
-    Array(Vec<Expression>),
+    Array(Vec<Self>),
     /// ```javascript
     /// 5
     /// 5.0
@@ -115,9 +126,36 @@ pub enum Expression {
     /// undefined
     /// ```
     Undefined,
+    /// IIFE
+    ///
+    /// ```javascript
+    /// (() => { block })()
+    /// ```
+    Block(Block),
+    /// ```javascript
+    /// 1 + 2
+    /// x && y
+    /// ```
+    Operator {
+        op: Operator,
+        lhs: Box<Self>,
+        rhs: Box<Self>,
+    },
+    IndexAccess {
+        target: Box<Self>,
+        index: Box<Self>,
+    },
+}
+
+/// A binary operator.
+#[derive(Clone)]
+pub enum Operator {
+    And,
+    Equals,
 }
 
 /// The _body_ of an arrow function.
+#[derive(Clone)]
 pub enum ArrowFunctionBody {
     /// ```javascript
     /// () => expression;
@@ -126,5 +164,5 @@ pub enum ArrowFunctionBody {
     /// ```javascript
     /// () => { block }
     /// ```
-    _Block(Block),
+    Block(Block),
 }

--- a/crates/ditto-cst/src/expression.rs
+++ b/crates/ditto-cst/src/expression.rs
@@ -1,7 +1,7 @@
 use crate::{
-    BracketsList, Colon, ElseKeyword, FalseKeyword, IfKeyword, Name, Parens, ParensList,
-    QualifiedName, QualifiedProperName, RightArrow, StringToken, ThenKeyword, TrueKeyword, Type,
-    UnitKeyword,
+    BracketsList, Colon, ElseKeyword, FalseKeyword, IfKeyword, MatchKeyword, Name, Parens,
+    ParensList, ParensList1, Pipe, QualifiedName, QualifiedProperName, RightArrow, StringToken,
+    ThenKeyword, TrueKeyword, Type, UnitKeyword, WithKeyword,
 };
 
 /// A value expression.
@@ -54,6 +54,24 @@ pub enum Expression {
         /// The expression to evaluate otherwise.
         false_clause: Box<Self>,
     },
+    /// A pattern match.
+    ///
+    /// ```ditto
+    /// match some_expr with
+    /// | Pattern -> another_expr
+    /// ```
+    Match {
+        /// `match`
+        match_keyword: MatchKeyword,
+        /// Expression to be matched.
+        expression: Box<Expression>,
+        /// `with`
+        with_keyword: WithKeyword,
+        /// The first match arm (there should be at least one).
+        head_arm: MatchArm,
+        /// More match arms.
+        tail_arms: Vec<MatchArm>,
+    },
     /// A value constructor, e.g. `Just` and `Ok`.
     Constructor(QualifiedProperName),
     /// A variable. Useful for not repeating things.
@@ -86,6 +104,45 @@ pub enum Expression {
     Float(StringToken),
     /// `[this, is, an, array]`
     Array(BracketsList<Box<Self>>),
+}
+
+/// A single arm of a `match` expression.
+///
+/// ```ditto
+/// | Pattern -> expression
+/// ```
+#[derive(Debug, Clone)]
+pub struct MatchArm {
+    /// `|`
+    pub pipe: Pipe,
+    /// Pattern to be matched.
+    pub pattern: Pattern,
+    /// `->`
+    pub right_arrow: RightArrow,
+    /// The expression to return if the pattern is matched.
+    pub expression: Box<Expression>,
+}
+
+/// A pattern to be matched.
+#[derive(Debug, Clone)]
+pub enum Pattern {
+    /// A constructor pattern without arguments.
+    NullaryConstructor {
+        /// `Maybe.Just`
+        constructor: QualifiedProperName,
+    },
+    /// A constructor pattern with arguments.
+    Constructor {
+        /// `Maybe.Just`
+        constructor: QualifiedProperName,
+        /// Pattern arguments to the constructor.
+        arguments: ParensList1<Box<Pattern>>,
+    },
+    /// A variable binding pattern.
+    Variable {
+        /// Name to bind.
+        name: Name,
+    },
 }
 
 /// `: String`

--- a/crates/ditto-cst/src/parser/grammar.pest
+++ b/crates/ditto-cst/src/parser/grammar.pest
@@ -131,6 +131,7 @@ return_type_annotation = { colon ~ type1 } // used for function expressions only
 expression = _ 
   { expression_call
   | expression_function
+  | expression_match
   | expression1
   }
 
@@ -157,6 +158,10 @@ expression_call = { expression1 ~ expression_call_arguments+   }
 
 expression_call_arguments = { open_paren ~ (expression ~ (comma ~ expression)* ~ comma?)?  ~ close_paren }
 
+expression_match = { match_keyword ~ expression ~ with_keyword ~ expression_match_arm+ }
+
+expression_match_arm = { pipe ~ pattern ~ right_arrow ~ expression }
+
 expression_constructor = { qualified_proper_name }
 
 expression_function = { expression_function_parameters ~ return_type_annotation? ~ right_arrow ~ expression }
@@ -182,6 +187,19 @@ expression_true = { true_keyword }
 expression_false = { false_keyword }
 
 expression_unit = { unit_keyword }
+
+pattern = 
+  { pattern_constructor
+  | pattern_variable
+  }
+
+pattern_constructor = { pattern_constructor_proper_name ~ pattern_constructor_arguments? }
+
+pattern_constructor_proper_name = { qualified_proper_name }
+
+pattern_constructor_arguments = { open_paren ~ (pattern ~ (comma ~ pattern)* ~ comma?)?  ~ close_paren }
+
+pattern_variable = { name }
 
 // -----------------------------------------------------------------------------
 // Names
@@ -230,6 +248,10 @@ as_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ AS_KEYWORD ~ HORIZONTAL_WHITESPAC
 type_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ TYPE_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
 
 foreign_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ FOREIGN_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+
+match_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ MATCH_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+
+with_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ WITH_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
 
 dot = ${ (WHITESPACE | LINE_COMMENT)* ~ DOT ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
 
@@ -293,6 +315,10 @@ AS_KEYWORD = { "as" }
 TYPE_KEYWORD = { "type" }
 
 FOREIGN_KEYWORD = { "foreign" }
+
+MATCH_KEYWORD = { "match" }
+
+WITH_KEYWORD = { "with" }
 
 DOT = { "." }
 

--- a/crates/ditto-cst/src/parser/token.rs
+++ b/crates/ditto-cst/src/parser/token.rs
@@ -43,6 +43,8 @@ impl_from_pair!(ElseKeyword, rule = Rule::else_keyword);
 impl_from_pair!(TypeKeyword, rule = Rule::type_keyword);
 impl_from_pair!(ForeignKeyword, rule = Rule::foreign_keyword);
 impl_from_pair!(Pipe, rule = Rule::pipe);
+impl_from_pair!(MatchKeyword, rule = Rule::match_keyword);
+impl_from_pair!(WithKeyword, rule = Rule::with_keyword);
 
 impl StringToken {
     pub(super) fn from_pairs(pairs: &mut Pairs<Rule>) -> Self {

--- a/crates/ditto-cst/src/token.rs
+++ b/crates/ditto-cst/src/token.rs
@@ -179,3 +179,11 @@ pub struct TypeKeyword(pub EmptyToken);
 /// `foreign`
 #[derive(Debug, Clone)]
 pub struct ForeignKeyword(pub EmptyToken);
+
+/// `match`
+#[derive(Debug, Clone)]
+pub struct MatchKeyword(pub EmptyToken);
+
+/// `with`
+#[derive(Debug, Clone)]
+pub struct WithKeyword(pub EmptyToken);

--- a/crates/ditto-fmt/golden-tests/match_expressions.ditto
+++ b/crates/ditto-fmt/golden-tests/match_expressions.ditto
@@ -1,0 +1,49 @@
+module If.Then.Else exports (..);
+
+
+octopus =
+    match arm with
+    | Arm1 -> "octopus"
+    | Arm2 ->  -- comment
+        "octopus"
+    | Arm3 ->
+        -- comment
+        "octopus"
+    | Arm4 -> "octopus"  -- comment
+    |  -- pls don't do this
+     Arm5 -> "octopus"
+    | Arm6  -- or this
+     -> "octopus"
+    --
+    --
+    --
+    | Arm.Arm7 -> if true then "octopus" else "octopus"
+    | Arm.Arm8 ->
+        if true then
+            -- still octopus
+            "octopus"
+        else
+            "octopus";
+
+-- it's a classic
+map_maybe = (fn, maybe) ->
+    -- it really is
+    match maybe with
+    | Just(a) -> fn(a)
+    | Nothing -> Nothing;
+
+all_the_args = () ->
+    match not_sure with
+    | Foo(a, b, c, d) -> unit
+    | Bar(Foo(a, b), b, Baz.Barrr, d) -> unit
+    | Foo(
+        -- comment
+        a,
+        B.B,
+        -- comment
+        C.C(a, b, c),
+        D.D(
+            -- comment
+            d,
+        ),
+    ) -> unit;

--- a/crates/ditto-fmt/src/has_comments.rs
+++ b/crates/ditto-fmt/src/has_comments.rs
@@ -57,6 +57,19 @@ impl HasComments for Expression {
                 function,
                 arguments,
             } => function.has_comments() || arguments.has_comments(),
+            Self::Match {
+                match_keyword,
+                expression,
+                with_keyword,
+                head_arm,
+                tail_arms,
+            } => {
+                match_keyword.0.has_comments()
+                    || expression.has_comments()
+                    || with_keyword.0.has_comments()
+                    || head_arm.has_comments()
+                    || tail_arms.iter().any(|arm| arm.has_comments())
+            }
         }
     }
 
@@ -75,6 +88,45 @@ impl HasComments for Expression {
             Self::If { if_keyword, .. } => if_keyword.0.has_leading_comments(),
             Self::Function { box parameters, .. } => parameters.open_paren.0.has_leading_comments(),
             Self::Call { function, .. } => function.has_leading_comments(),
+            Self::Match { match_keyword, .. } => match_keyword.0.has_leading_comments(),
+        }
+    }
+}
+
+impl HasComments for MatchArm {
+    fn has_comments(&self) -> bool {
+        let Self {
+            pipe,
+            pattern,
+            right_arrow,
+            expression,
+        } = self;
+        pipe.0.has_comments()
+            || pattern.has_comments()
+            || right_arrow.0.has_comments()
+            || expression.has_comments()
+    }
+    fn has_leading_comments(&self) -> bool {
+        self.pipe.0.has_leading_comments()
+    }
+}
+
+impl HasComments for Pattern {
+    fn has_comments(&self) -> bool {
+        match self {
+            Self::NullaryConstructor { constructor } => constructor.has_comments(),
+            Self::Constructor {
+                constructor,
+                arguments,
+            } => constructor.has_comments() || arguments.has_comments(),
+            Self::Variable { name } => name.has_comments(),
+        }
+    }
+    fn has_leading_comments(&self) -> bool {
+        match self {
+            Self::NullaryConstructor { constructor } => constructor.has_leading_comments(),
+            Self::Constructor { constructor, .. } => constructor.has_leading_comments(),
+            Self::Variable { name } => name.has_leading_comments(),
         }
     }
 }

--- a/crates/ditto-fmt/src/token.rs
+++ b/crates/ditto-fmt/src/token.rs
@@ -32,6 +32,8 @@ gen_empty_token_like!(gen_unit_keyword, cst::UnitKeyword, "unit");
 gen_empty_token_like!(gen_if_keyword, cst::IfKeyword, "if");
 gen_empty_token_like!(gen_then_keyword, cst::ThenKeyword, "then");
 gen_empty_token_like!(gen_else_keyword, cst::ElseKeyword, "else");
+gen_empty_token_like!(gen_match_keyword, cst::MatchKeyword, "match");
+gen_empty_token_like!(gen_with_keyword, cst::WithKeyword, "with");
 gen_empty_token_like!(gen_exports_keyword, cst::ExportsKeyword, "exports");
 gen_empty_token_like!(gen_as_keyword, cst::AsKeyword, "as");
 gen_empty_token_like!(gen_type_keyword, cst::TypeKeyword, "type");

--- a/crates/ditto-lsp/src/semantic_tokens.rs
+++ b/crates/ditto-lsp/src/semantic_tokens.rs
@@ -111,6 +111,8 @@ impl TokensBuilder {
               "as"
               "type"
               "foreign"
+              "match"
+              "with"
             ] @keyword
 
             ; 2, 3, 4


### PR DESCRIPTION
- [x] Parse the new expression type in `ditto-cst`
- [x] Add the new expression type to `ditto-ast`
- [x] Type check the new expression type in `ditto-checker`
- [x] Extend the JavaScript code generator
- [x] Extend the expression formatting logic in `ditto-fmt`