### PR TITLE
Don't run expensive workflow jobs for draft PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,7 +144,8 @@ jobs:
           args: --all-features
 
   not-draft:
-    name: draft PR?
+    # https://knowyourmeme.com/memes/you-shall-not-pass
+    name: Shall pass? 🧙
     runs-on: ubuntu-latest
     steps:
       - name: PR not ready 🙅

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ on:
 jobs:
   check:
     name: Check 🕵️
+    needs: [not-draft]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -29,7 +30,7 @@ jobs:
 
   test:
     name: Run tests 🧪
-    needs: check
+    needs: [not-draft, check]
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -123,6 +124,7 @@ jobs:
 
   clippy:
     name: Run clippy 📎
+    needs: [not-draft]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -139,3 +141,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features
+
+  not-draft:
+    name: Check if CI should run 🧑‍✈️
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR not ready 🙅
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == true
+        run: exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   check:
-    name: Check 🕵️
+    name: cargo check 🕵️
     needs: [not-draft]
     runs-on: ubuntu-latest
     steps:
@@ -29,7 +29,7 @@ jobs:
           command: check
 
   test:
-    name: Run tests 🧪
+    name: cargo test 🧪
     needs: [not-draft, check]
     strategy:
       matrix:
@@ -87,7 +87,7 @@ jobs:
           token: ${{secrets.CODECOV_TOKEN}}
 
   rustfmt-check:
-    name: Check rustfmt 💅
+    name: rustfmt 💅
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -105,7 +105,7 @@ jobs:
           args: --check --all
 
   prettier-check:
-    name: Check prettier 💅
+    name: prettier 💅
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -123,7 +123,7 @@ jobs:
       - run: npm run format:check
 
   clippy:
-    name: Run clippy 📎
+    name: clippy 📎
     needs: [not-draft]
     runs-on: ubuntu-latest
     steps:
@@ -143,7 +143,7 @@ jobs:
           args: --all-features
 
   not-draft:
-    name: Check if CI should run 🧑‍✈️
+    name: draft PR?
     runs-on: ubuntu-latest
     steps:
       - name: PR not ready 🙅


### PR DESCRIPTION
Draft PRs aren't _expected_ to be in a good/working state, so there's no point using valuable GitHub action minutes on them.
