### PR TITLE
Add `do` expressions

### DIFF
--- a/crates/ditto-ast/src/type.rs
+++ b/crates/ditto-ast/src/type.rs
@@ -59,6 +59,8 @@ pub enum Type {
 /// Ditto's primitive types.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum PrimType {
+    /// `do { return 5 } : Effect(Int)`
+    Effect,
     /// `[] : Array(a)`
     Array,
     /// `5 : Int`
@@ -76,6 +78,7 @@ pub enum PrimType {
 impl fmt::Display for PrimType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Effect => write!(f, "Effect"),
             Self::Array => write!(f, "Array"),
             Self::Int => write!(f, "Int"),
             Self::Float => write!(f, "Float"),
@@ -94,6 +97,9 @@ impl PrimType {
     /// Return the kind of the given primitive.
     pub fn get_kind(&self) -> Kind {
         match self {
+            Self::Effect => Kind::Function {
+                parameters: NonEmpty::new(Kind::Type),
+            },
             Self::Array => Kind::Function {
                 parameters: NonEmpty::new(Kind::Type),
             },

--- a/crates/ditto-checker/golden-tests/type-errors/effect_unification_error_0.ditto
+++ b/crates/ditto-checker/golden-tests/type-errors/effect_unification_error_0.ditto
@@ -1,0 +1,6 @@
+module Test exports (..);
+
+not_an_effect = do {
+    huh <- 5;
+    return unit
+};

--- a/crates/ditto-checker/golden-tests/type-errors/effect_unification_error_0.error
+++ b/crates/ditto-checker/golden-tests/type-errors/effect_unification_error_0.error
@@ -1,0 +1,14 @@
+
+  × types don't unify
+   ╭─[golden:1:1]
+ 1 │ module Test exports (..);
+ 2 │ 
+ 3 │ not_an_effect = do {
+ 4 │     huh <- 5;
+   ·            ┬
+   ·            ╰── here
+ 5 │     return unit
+ 6 │ };
+   ╰────
+  help: expected Effect($1)
+        got Int

--- a/crates/ditto-checker/golden-tests/warnings/unused_effect_binder.ditto
+++ b/crates/ditto-checker/golden-tests/warnings/unused_effect_binder.ditto
@@ -1,0 +1,10 @@
+module Test exports (..);
+
+get_name : Effect(String) = do {
+    return "jane"
+};
+
+greet : Effect(Unit) = do {
+    name <- get_name;
+    return unit
+};

--- a/crates/ditto-checker/golden-tests/warnings/unused_effect_binder.warnings
+++ b/crates/ditto-checker/golden-tests/warnings/unused_effect_binder.warnings
@@ -1,0 +1,12 @@
+
+  ⚠ unused effect binder
+    ╭─[golden:5:1]
+  5 │ };
+  6 │ 
+  7 │ greet : Effect(Unit) = do {
+  8 │     name <- get_name;
+    ·     ──┬─
+    ·       ╰── this isn't used
+  9 │     return unit
+ 10 │ };
+    ╰────

--- a/crates/ditto-checker/src/kindchecker/env.rs
+++ b/crates/ditto-checker/src/kindchecker/env.rs
@@ -30,6 +30,10 @@ lazy_static! {
             unqualified(PrimType::Array.as_proper_name()),
             EnvType::PrimConstructor(PrimType::Array),
         ),
+        (
+            unqualified(PrimType::Effect.as_proper_name()),
+            EnvType::PrimConstructor(PrimType::Effect),
+        ),
     ]);
 }
 

--- a/crates/ditto-checker/src/result/warnings.rs
+++ b/crates/ditto-checker/src/result/warnings.rs
@@ -29,6 +29,9 @@ pub enum Warning {
     UnusedFunctionBinder {
         span: Span,
     },
+    UnusedEffectBinder {
+        span: Span,
+    },
     UnusedValueDeclaration {
         span: Span,
     },
@@ -79,6 +82,9 @@ impl Warning {
                 duplicate_import: span_to_source_span(duplicate_import),
             },
             Self::UnusedFunctionBinder { span } => WarningReport::UnusedFunctionBinder {
+                location: span_to_source_span(span),
+            },
+            Self::UnusedEffectBinder { span } => WarningReport::UnusedEffectBinder {
                 location: span_to_source_span(span),
             },
             Self::UnusedValueDeclaration { span } => WarningReport::UnusedValueDeclaration {
@@ -150,6 +156,13 @@ pub enum WarningReport {
     #[error("unused function binder")]
     #[diagnostic(severity(Warning))]
     UnusedFunctionBinder {
+        #[label("this isn't used")]
+        #[serde(with = "SourceSpanDef")]
+        location: SourceSpan,
+    },
+    #[error("unused effect binder")]
+    #[diagnostic(severity(Warning))]
+    UnusedEffectBinder {
         #[label("this isn't used")]
         #[serde(with = "SourceSpanDef")]
         location: SourceSpan,

--- a/crates/ditto-checker/src/typechecker/tests/effect.rs
+++ b/crates/ditto-checker/src/typechecker/tests/effect.rs
@@ -1,0 +1,32 @@
+use super::macros::*;
+use crate::{TypeError::*, Warning::*};
+
+#[test]
+fn it_typechecks_as_expected() {
+    assert_type!(r#" do { return 5 } "#, "Effect(Int)");
+    assert_type!(r#" do { do { return unit } } "#, "Effect(Unit)");
+    assert_type!(
+        r#" do { hi <- do { return "hi" }; return hi } "#,
+        "Effect(String)"
+    );
+
+    assert_type!(
+        r#" (get_bool: Effect(Bool)) -> do { b <- get_bool; return b } "#,
+        "(Effect(Bool)) -> Effect(Bool)"
+    );
+}
+
+#[test]
+fn it_errors_as_expected() {
+    assert_type_error!(r#" do { 5 }"#, TypesNotEqual { .. });
+    assert_type_error!(r#" do { x <- 5; return x }"#, TypesNotEqual { .. });
+}
+
+#[test]
+fn it_warns_as_expected() {
+    assert_type!(
+        "do { x <- do { return 5 }; return 10 }",
+        "Effect(Int)",
+        [UnusedEffectBinder { .. }]
+    );
+}

--- a/crates/ditto-checker/src/typechecker/tests/mod.rs
+++ b/crates/ditto-checker/src/typechecker/tests/mod.rs
@@ -2,6 +2,7 @@ mod array;
 mod bool;
 mod call;
 mod cond;
+mod effect;
 mod float;
 mod function;
 mod int;

--- a/crates/ditto-codegen-js/golden-tests/javascript/effect_expressions.ditto
+++ b/crates/ditto-codegen-js/golden-tests/javascript/effect_expressions.ditto
@@ -1,0 +1,20 @@
+module Test exports (..);
+
+get_name = do {
+    return "jane"
+};
+
+get_names = do {
+    name <- get_name;
+    another_name <- get_name;
+    return [name, another_name]
+};
+
+effect_map = (effect_a: Effect(a), fn: (a) -> b): Effect(b) -> do {
+    a <- effect_a;
+    return fn(a)
+};
+
+main : Effect(Unit) = do {
+    effect_map(get_name, (name) -> unit)
+};

--- a/crates/ditto-codegen-js/golden-tests/javascript/effect_expressions.js
+++ b/crates/ditto-codegen-js/golden-tests/javascript/effect_expressions.js
@@ -1,0 +1,18 @@
+function effect_map(effect_a, fn) {
+  return () => {
+    const a = effect_a();
+    return fn(a);
+  };
+}
+function get_name() {
+  return "jane";
+}
+function main() {
+  effect_map(get_name, name => undefined)();
+}
+function get_names() {
+  const name = get_name();
+  const another_name = get_name();
+  return [name, another_name];
+}
+export { effect_map, get_name, get_names, main };

--- a/crates/ditto-codegen-js/src/ast.rs
+++ b/crates/ditto-codegen-js/src/ast.rs
@@ -45,6 +45,18 @@ pub enum ModuleStatement {
     },
 }
 
+impl ModuleStatement {
+    /// Get the identifier for this module statement.
+    pub fn ident(&self) -> &Ident {
+        match self {
+            Self::ConstAssignment { ident, .. } => ident,
+            Self::Assignment { ident, .. } => ident,
+            Self::LetDeclaration { ident, .. } => ident,
+            Self::Function { ident, .. } => ident,
+        }
+    }
+}
+
 /// A bunch of statements surrounded by braces.
 #[derive(Clone)]
 pub struct Block(pub Vec<BlockStatement>);
@@ -61,7 +73,7 @@ pub enum BlockStatement {
     /// ```javascript
     /// console.log("hi");
     /// ```
-    _Expression(Expression),
+    Expression(Expression),
     /// ```javascript
     /// throw new Error("message")
     /// ```

--- a/crates/ditto-codegen-js/src/render.rs
+++ b/crates/ditto-codegen-js/src/render.rs
@@ -115,7 +115,7 @@ impl Render for BlockStatement {
                 expression.render(accum);
                 accum.push(';');
             }
-            Self::_Expression(expression) => {
+            Self::Expression(expression) => {
                 expression.render(accum);
                 accum.push(';');
             }

--- a/crates/ditto-codegen-js/src/ts.rs
+++ b/crates/ditto-codegen-js/src/ts.rs
@@ -196,6 +196,11 @@ fn convert_type_rec(
         ast::Type::PrimConstructor(ast::PrimType::Bool) => ident!("boolean").into(),
         ast::Type::PrimConstructor(ast::PrimType::Unit) => ident!("undefined").into(),
 
+        ast::Type::PrimConstructor(ast::PrimType::Effect) => {
+            // :thinking:
+            todo!();
+        }
+
         ast::Type::Variable {
             var, variable_kind, ..
         } => {

--- a/crates/ditto-cst/src/get_span.rs
+++ b/crates/ditto-cst/src/get_span.rs
@@ -98,6 +98,11 @@ impl Expression {
                 false_clause,
                 ..
             } => if_keyword.0.get_span().merge(&false_clause.get_span()),
+            Self::Effect {
+                do_keyword,
+                close_brace,
+                ..
+            } => do_keyword.0.get_span().merge(&close_brace.0.get_span()),
             Self::String(string_token) => string_token.get_span(),
             Self::Int(int_token) => int_token.get_span(),
             Self::Float(float_token) => float_token.get_span(),

--- a/crates/ditto-cst/src/parser/grammar.pest
+++ b/crates/ditto-cst/src/parser/grammar.pest
@@ -132,6 +132,7 @@ expression = _
   { expression_call
   | expression_function
   | expression_match
+  | expression_effect
   | expression1
   }
 
@@ -161,6 +162,20 @@ expression_call_arguments = { open_paren ~ (expression ~ (comma ~ expression)* ~
 expression_match = { match_keyword ~ expression ~ with_keyword ~ expression_match_arm+ }
 
 expression_match_arm = { pipe ~ pattern ~ right_arrow ~ expression }
+
+expression_effect = { do_keyword ~ open_brace ~ expression_effect_statement ~ close_brace }
+
+expression_effect_statement = _
+  { expression_effect_return
+  | expression_effect_bind
+  | expression_effect_expression
+  }
+
+expression_effect_return = { return_keyword ~ expression }
+
+expression_effect_bind = { name ~ left_arrow ~ expression ~ semicolon ~ expression_effect_statement }
+
+expression_effect_expression = { expression ~ (semicolon ~ expression_effect_statement)? }
 
 expression_constructor = { qualified_proper_name }
 
@@ -251,6 +266,12 @@ foreign_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ FOREIGN_KEYWORD ~ HORIZONTAL
 
 match_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ MATCH_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
 
+do_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ DO_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+
+return_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ RETURN_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+
+let_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ LET_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+
 with_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ WITH_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
 
 dot = ${ (WHITESPACE | LINE_COMMENT)* ~ DOT ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
@@ -269,6 +290,8 @@ equals = ${ (WHITESPACE | LINE_COMMENT)* ~ EQUALS ~ HORIZONTAL_WHITESPACE? ~ LIN
 
 right_arrow = ${ (WHITESPACE | LINE_COMMENT)* ~ RIGHT_ARROW ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
 
+left_arrow = ${ (WHITESPACE | LINE_COMMENT)* ~ LEFT_ARROW ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+
 open_paren = ${ (WHITESPACE | LINE_COMMENT)* ~ OPEN_PAREN ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
 
 close_paren = ${ (WHITESPACE | LINE_COMMENT)* ~ CLOSE_PAREN ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
@@ -276,6 +299,10 @@ close_paren = ${ (WHITESPACE | LINE_COMMENT)* ~ CLOSE_PAREN ~ HORIZONTAL_WHITESP
 open_bracket = ${ (WHITESPACE | LINE_COMMENT)* ~ OPEN_BRACKET ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
 
 close_bracket = ${ (WHITESPACE | LINE_COMMENT)* ~ CLOSE_BRACKET ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+
+open_brace = ${ (WHITESPACE | LINE_COMMENT)* ~ OPEN_BRACE ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+
+close_brace = ${ (WHITESPACE | LINE_COMMENT)* ~ CLOSE_BRACE ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
 
 // -----------------------------------------------------------------------------
 // Atom rules (uppercase by convention)
@@ -318,6 +345,12 @@ FOREIGN_KEYWORD = { "foreign" }
 
 MATCH_KEYWORD = { "match" }
 
+DO_KEYWORD = { "do" }
+
+RETURN_KEYWORD = { "return" }
+
+LET_KEYWORD = { "let" }
+
 WITH_KEYWORD = { "with" }
 
 DOT = { "." }
@@ -336,6 +369,8 @@ EQUALS = { "=" }
 
 RIGHT_ARROW = { "->" }
 
+LEFT_ARROW = { "<-" }
+
 OPEN_PAREN = { "(" }
 
 CLOSE_PAREN = { ")" }
@@ -343,6 +378,10 @@ CLOSE_PAREN = { ")" }
 OPEN_BRACKET = { "[" }
 
 CLOSE_BRACKET = { "]" }
+
+OPEN_BRACE = { "{" }
+
+CLOSE_BRACE = { "}" }
 
 DOUBLE_QUOTE = { "\"" }
 

--- a/crates/ditto-cst/src/parser/token.rs
+++ b/crates/ditto-cst/src/parser/token.rs
@@ -2,9 +2,10 @@
 
 use super::Rule;
 use crate::{
-    AsKeyword, CloseBracket, CloseParen, Colon, Comma, Comment, DoubleDot, EmptyToken, Equals,
-    ExportsKeyword, FalseKeyword, ForeignKeyword, ImportKeyword, ModuleKeyword, OpenBracket,
-    OpenParen, Pipe, RightArrow, Span, StringToken, TrueKeyword, TypeKeyword, UnitKeyword,
+    AsKeyword, CloseBrace, CloseBracket, CloseParen, Colon, Comma, Comment, DoKeyword, DoubleDot,
+    EmptyToken, Equals, ExportsKeyword, FalseKeyword, ForeignKeyword, ImportKeyword, LeftArrow,
+    LetKeyword, ModuleKeyword, OpenBrace, OpenBracket, OpenParen, Pipe, ReturnKeyword, RightArrow,
+    Span, StringToken, TrueKeyword, TypeKeyword, UnitKeyword,
 };
 use pest::iterators::{Pair, Pairs};
 
@@ -24,10 +25,13 @@ impl_from_pair!(OpenParen, rule = Rule::open_paren);
 impl_from_pair!(CloseParen, rule = Rule::close_paren);
 impl_from_pair!(Comma, rule = Rule::comma);
 impl_from_pair!(RightArrow, rule = Rule::right_arrow);
+impl_from_pair!(LeftArrow, rule = Rule::left_arrow);
 impl_from_pair!(Colon, rule = Rule::colon);
 impl_from_pair!(Semicolon, rule = Rule::semicolon);
 impl_from_pair!(OpenBracket, rule = Rule::open_bracket);
 impl_from_pair!(CloseBracket, rule = Rule::close_bracket);
+impl_from_pair!(OpenBrace, rule = Rule::open_brace);
+impl_from_pair!(CloseBrace, rule = Rule::close_brace);
 impl_from_pair!(ImportKeyword, rule = Rule::import_keyword);
 impl_from_pair!(AsKeyword, rule = Rule::as_keyword);
 impl_from_pair!(DoubleDot, rule = Rule::double_dot);
@@ -45,6 +49,9 @@ impl_from_pair!(ForeignKeyword, rule = Rule::foreign_keyword);
 impl_from_pair!(Pipe, rule = Rule::pipe);
 impl_from_pair!(MatchKeyword, rule = Rule::match_keyword);
 impl_from_pair!(WithKeyword, rule = Rule::with_keyword);
+//impl_from_pair!(LetKeyword, rule = Rule::let_keyword);
+impl_from_pair!(DoKeyword, rule = Rule::do_keyword);
+impl_from_pair!(ReturnKeyword, rule = Rule::return_keyword);
 
 impl StringToken {
     pub(super) fn from_pairs(pairs: &mut Pairs<Rule>) -> Self {

--- a/crates/ditto-cst/src/token.rs
+++ b/crates/ditto-cst/src/token.rs
@@ -120,6 +120,14 @@ pub struct OpenBracket(pub EmptyToken);
 #[derive(Debug, Clone)]
 pub struct CloseBracket(pub EmptyToken);
 
+/// `{`
+#[derive(Debug, Clone)]
+pub struct OpenBrace(pub EmptyToken);
+
+/// `}`
+#[derive(Debug, Clone)]
+pub struct CloseBrace(pub EmptyToken);
+
 /// `<-`
 #[derive(Debug, Clone)]
 pub struct LeftArrow(pub EmptyToken);
@@ -187,3 +195,15 @@ pub struct MatchKeyword(pub EmptyToken);
 /// `with`
 #[derive(Debug, Clone)]
 pub struct WithKeyword(pub EmptyToken);
+
+/// `let`
+#[derive(Debug, Clone)]
+pub struct LetKeyword(pub EmptyToken);
+
+/// `do`
+#[derive(Debug, Clone)]
+pub struct DoKeyword(pub EmptyToken);
+
+/// `return`
+#[derive(Debug, Clone)]
+pub struct ReturnKeyword(pub EmptyToken);

--- a/crates/ditto-fmt/golden-tests/effect_expressions.ditto
+++ b/crates/ditto-fmt/golden-tests/effect_expressions.ditto
@@ -1,0 +1,59 @@
+module Effect exports (..);
+
+
+get_name = do {
+    return "jane"
+};
+
+get_names = do {
+    name <- get_name;
+    another_name <- get_name;
+    return [name, another_name]
+};
+
+effect_map = (effect_a: Effect(a), fn: (a) -> b): Effect(b) -> do {
+    a <- effect_a;
+    return fn(a)
+};
+
+main: Effect(Unit) = do {
+    effect_map(get_name, (name) -> unit)
+};
+
+bind_comments = do {
+    -- comment
+    whatever <- do_whatever();
+    whatever <- do_whatever();  -- comment
+    whatever <- do_whatever(
+        -- comment
+    );
+    whatever <-
+        -- comment
+        do_whatever();
+    whatever <-  -- comment
+        do_whatever();
+    return 5
+};
+
+nested = do {
+    five <- do {
+        return 5
+    };
+    return 5
+};
+
+if_then_else_effects = do {
+    yey_or_ney <-
+        if true then
+            -- comment
+            yey
+        else
+            ney;
+    if true then do_if_true() else do_if_false();
+    -- comment
+    if true then
+        -- comment
+        do_if_true()
+    else
+        do_if_false()
+};

--- a/crates/ditto-fmt/golden-tests/match_expressions.ditto
+++ b/crates/ditto-fmt/golden-tests/match_expressions.ditto
@@ -1,4 +1,4 @@
-module If.Then.Else exports (..);
+module Match exports (..);
 
 
 octopus =

--- a/crates/ditto-fmt/src/has_comments.rs
+++ b/crates/ditto-fmt/src/has_comments.rs
@@ -70,6 +70,17 @@ impl HasComments for Expression {
                     || head_arm.has_comments()
                     || tail_arms.iter().any(|arm| arm.has_comments())
             }
+            Self::Effect {
+                do_keyword,
+                open_brace,
+                effect,
+                close_brace,
+            } => {
+                do_keyword.0.has_comments()
+                    || open_brace.0.has_comments()
+                    || effect.has_comments()
+                    || close_brace.0.has_comments()
+            }
         }
     }
 
@@ -89,7 +100,43 @@ impl HasComments for Expression {
             Self::Function { box parameters, .. } => parameters.open_paren.0.has_leading_comments(),
             Self::Call { function, .. } => function.has_leading_comments(),
             Self::Match { match_keyword, .. } => match_keyword.0.has_leading_comments(),
+            Self::Effect { do_keyword, .. } => do_keyword.0.has_leading_comments(),
         }
+    }
+}
+
+impl HasComments for Effect {
+    fn has_comments(&self) -> bool {
+        match self {
+            Self::Return {
+                return_keyword,
+                expression,
+            } => return_keyword.0.has_comments() || expression.has_comments(),
+            Self::Bind {
+                name,
+                left_arrow,
+                expression,
+                semicolon,
+                rest,
+            } => {
+                name.has_comments()
+                    || left_arrow.0.has_comments()
+                    || expression.has_comments()
+                    || semicolon.0.has_comments()
+                    || rest.has_comments()
+            }
+            Self::Expression {
+                expression,
+                rest: None,
+            } => expression.has_comments(),
+            Self::Expression {
+                expression,
+                rest: Some((semicolon, rest)),
+            } => expression.has_comments() || semicolon.0.has_comments() || rest.has_comments(),
+        }
+    }
+    fn has_leading_comments(&self) -> bool {
+        todo!()
     }
 }
 

--- a/crates/ditto-fmt/src/token.rs
+++ b/crates/ditto-fmt/src/token.rs
@@ -40,6 +40,7 @@ gen_empty_token_like!(gen_type_keyword, cst::TypeKeyword, "type");
 gen_empty_token_like!(gen_import_keyword, cst::ImportKeyword, "import");
 gen_empty_token_like!(gen_foreign_keyword, cst::ForeignKeyword, "foreign");
 gen_empty_token_like!(gen_open_bracket, cst::OpenBracket, "[");
+gen_empty_token_like!(gen_open_brace, cst::OpenBrace, "{");
 gen_empty_token_like!(gen_pipe, cst::Pipe, "|");
 gen_empty_token_like!(gen_open_paren, cst::OpenParen, "(");
 gen_empty_token_like!(gen_comma, cst::Comma, ",");
@@ -49,7 +50,10 @@ gen_empty_token_like!(gen_double_dot, cst::DoubleDot, "..");
 gen_empty_token_like!(gen_colon, cst::Colon, ":");
 gen_empty_token_like!(gen_semicolon, cst::Semicolon, ";");
 gen_empty_token_like!(gen_right_arrow, cst::RightArrow, "->");
+gen_empty_token_like!(gen_left_arrow, cst::LeftArrow, "<-");
 gen_empty_token_like!(gen_module_keyword, cst::ModuleKeyword, "module");
+gen_empty_token_like!(gen_do_keyword, cst::DoKeyword, "do");
+gen_empty_token_like!(gen_return_keyword, cst::ReturnKeyword, "return");
 gen_empty_token_like!(
     gen_close_bracket,
     cst::CloseBracket,
@@ -62,6 +66,14 @@ gen_empty_token_like!(
     gen_close_paren,
     cst::CloseParen,
     ")",
+    GenTokenOptions {
+        indent_leading_comments: true,
+    }
+);
+gen_empty_token_like!(
+    gen_close_brace,
+    cst::CloseBrace,
+    "}",
     GenTokenOptions {
         indent_leading_comments: true,
     }

--- a/crates/ditto-lsp/src/semantic_tokens.rs
+++ b/crates/ditto-lsp/src/semantic_tokens.rs
@@ -113,6 +113,8 @@ impl TokensBuilder {
               "foreign"
               "match"
               "with"
+              "do"
+              "return"
             ] @keyword
 
             ; 2, 3, 4


### PR DESCRIPTION
- [x] Parse the new expression type in `ditto-cst`
- [x] Add the new expression type to `ditto-ast`
- [x] Type check the new expression type in `ditto-checker`
- [x] Extend the JavaScript code generator
- [x] Extend the expression formatting logic in `ditto-fmt`
- [x] Add new keywords to the LSP semantic token logic