### PR TITLE
Add the pipe operator `|>`

### DIFF
--- a/crates/ditto-checker/golden-tests/type-errors/argument_length_mismatch_3.ditto
+++ b/crates/ditto-checker/golden-tests/type-errors/argument_length_mismatch_3.ditto
@@ -1,0 +1,3 @@
+module Test exports (..);
+
+bad_pipe = 5 |> (() -> 10);

--- a/crates/ditto-checker/golden-tests/type-errors/argument_length_mismatch_3.error
+++ b/crates/ditto-checker/golden-tests/type-errors/argument_length_mismatch_3.error
@@ -1,0 +1,9 @@
+
+  × wrong number of arguments
+   ╭─[golden:1:1]
+ 1 │ module Test exports (..);
+ 2 │ 
+ 3 │ bad_pipe = 5 |> (() -> 10);
+   ·                  ────┬───
+   ·                      ╰── this expects no arguments
+   ╰────

--- a/crates/ditto-checker/golden-tests/type-errors/not_a_function_1.ditto
+++ b/crates/ditto-checker/golden-tests/type-errors/not_a_function_1.ditto
@@ -1,0 +1,3 @@
+module Test exports (..);
+
+huh = 5 |> 5;

--- a/crates/ditto-checker/golden-tests/type-errors/not_a_function_1.error
+++ b/crates/ditto-checker/golden-tests/type-errors/not_a_function_1.error
@@ -1,0 +1,10 @@
+
+  × expression isn't callable
+   ╭─[golden:1:1]
+ 1 │ module Test exports (..);
+ 2 │ 
+ 3 │ huh = 5 |> 5;
+   ·            ┬
+   ·            ╰── can't call this
+   ╰────
+  help: expression has type: Int

--- a/crates/ditto-checker/golden-tests/type-errors/unification_error_4.ditto
+++ b/crates/ditto-checker/golden-tests/type-errors/unification_error_4.ditto
@@ -1,0 +1,5 @@
+module Test exports (..);
+
+identity_int = (n: Int): Int -> n;
+
+huh = "nope" |> identity_int;

--- a/crates/ditto-checker/golden-tests/type-errors/unification_error_4.error
+++ b/crates/ditto-checker/golden-tests/type-errors/unification_error_4.error
@@ -1,0 +1,12 @@
+
+  × types don't unify
+   ╭─[golden:2:1]
+ 2 │ 
+ 3 │ identity_int = (n: Int): Int -> n;
+ 4 │ 
+ 5 │ huh = "nope" |> identity_int;
+   ·       ───┬──
+   ·          ╰── here
+   ╰────
+  help: expected Int
+        got String

--- a/crates/ditto-checker/src/module/value_declarations/mod.rs
+++ b/crates/ditto-checker/src/module/value_declarations/mod.rs
@@ -480,6 +480,14 @@ fn toposort_value_declarations(
             Expression::Parens(parens) => {
                 get_connected_nodes_rec(&parens.value, nodes, accum);
             }
+            Expression::BinOp {
+                box lhs,
+                operator: _,
+                box rhs,
+            } => {
+                get_connected_nodes_rec(lhs, nodes, accum);
+                get_connected_nodes_rec(rhs, nodes, accum);
+            }
             // noop
             Expression::Constructor(_qualified_proper_name) => {}
             Expression::String(_) => {}

--- a/crates/ditto-checker/src/typechecker/pre_ast.rs
+++ b/crates/ditto-checker/src/typechecker/pre_ast.rs
@@ -302,6 +302,39 @@ fn convert_cst(
                 body: Box::new(body),
             })
         }
+        cst::Expression::BinOp {
+            box lhs,
+            // Desugar!
+            operator: cst::BinOp::RightPizza(_),
+            box rhs,
+        } => {
+            let lhs = convert_cst(env, state, lhs)?;
+            let rhs = convert_cst(env, state, rhs)?;
+            match rhs {
+                Expression::Call {
+                    span,
+                    function,
+                    arguments: original_arguments,
+                } => {
+                    // Push the lhs as the first argument to the rhs
+                    let mut arguments = vec![Argument::Expression(lhs)];
+                    arguments.extend(original_arguments);
+                    Ok(Expression::Call {
+                        span,
+                        function,
+                        arguments,
+                    })
+                }
+                function => {
+                    let arguments = vec![Argument::Expression(lhs)];
+                    Ok(Expression::Call {
+                        span,
+                        function: Box::new(function),
+                        arguments,
+                    })
+                }
+            }
+        }
     }
 }
 

--- a/crates/ditto-checker/src/typechecker/tests/mod.rs
+++ b/crates/ditto-checker/src/typechecker/tests/mod.rs
@@ -8,5 +8,6 @@ mod function;
 mod int;
 pub(self) mod macros;
 mod r#match;
+mod right_pipe;
 mod string;
 mod unit;

--- a/crates/ditto-checker/src/typechecker/tests/right_pipe.rs
+++ b/crates/ditto-checker/src/typechecker/tests/right_pipe.rs
@@ -1,0 +1,17 @@
+use super::macros::*;
+use crate::TypeError::*;
+
+#[test]
+fn it_typechecks_as_expected() {
+    assert_type!("(f) -> 5 |> f", "((Int) -> $1) -> $1");
+    assert_type!("(f) -> 5 |> f()", "((Int) -> $1) -> $1");
+    assert_type!("(f, g) -> 5 |> f |> g", "((Int) -> $2, ($2) -> $3) -> $3");
+    assert_type!("5 |> ((n) -> n)", "Int");
+    assert_type!("5 |> ((n) -> n)()", "Int");
+}
+
+#[test]
+fn it_errors_as_expected() {
+    assert_type_error!("5 |> 5", NotAFunction { .. });
+    assert_type_error!("5 |> (() -> 5)", ArgumentLengthMismatch { .. });
+}

--- a/crates/ditto-codegen-js/golden-tests/javascript/pipe_expressions.ditto
+++ b/crates/ditto-codegen-js/golden-tests/javascript/pipe_expressions.ditto
@@ -1,0 +1,18 @@
+module Test exports (..);
+
+identity = (a) -> a;
+
+with_parens = 5 |> identity;
+without_parens = 5 |> identity();
+
+inline_function = 5 |> ((n) -> n);
+
+tagged_identity = (a, tag) -> a;
+
+-- these two should look the same in the generated code!
+want = tagged_identity(tagged_identity(tagged_identity(5, "1"), "2"), "3");
+got_ = 
+    5 
+    |> tagged_identity("1") 
+    |> tagged_identity("2") 
+    |> tagged_identity("3");

--- a/crates/ditto-codegen-js/golden-tests/javascript/pipe_expressions.js
+++ b/crates/ditto-codegen-js/golden-tests/javascript/pipe_expressions.js
@@ -1,0 +1,26 @@
+function tagged_identity(a, tag) {
+  return a;
+}
+const got_ = tagged_identity(
+  tagged_identity(tagged_identity(5, "1"), "2"),
+  "3",
+);
+const want = tagged_identity(
+  tagged_identity(tagged_identity(5, "1"), "2"),
+  "3",
+);
+const inline_function = (n => n)(5);
+function identity(a) {
+  return a;
+}
+const without_parens = identity(5);
+const with_parens = identity(5);
+export {
+  got_,
+  identity,
+  inline_function,
+  tagged_identity,
+  want,
+  with_parens,
+  without_parens,
+};

--- a/crates/ditto-cst/src/expression.rs
+++ b/crates/ditto-cst/src/expression.rs
@@ -1,8 +1,8 @@
 use crate::{
     BracketsList, CloseBrace, Colon, DoKeyword, ElseKeyword, FalseKeyword, IfKeyword, LeftArrow,
     MatchKeyword, Name, OpenBrace, Parens, ParensList, ParensList1, Pipe, QualifiedName,
-    QualifiedProperName, ReturnKeyword, RightArrow, Semicolon, StringToken, ThenKeyword,
-    TrueKeyword, Type, UnitKeyword, WithKeyword,
+    QualifiedProperName, ReturnKeyword, RightArrow, RightPizzaOperator, Semicolon, StringToken,
+    ThenKeyword, TrueKeyword, Type, UnitKeyword, WithKeyword,
 };
 
 /// A value expression.
@@ -125,6 +125,22 @@ pub enum Expression {
     Float(StringToken),
     /// `[this, is, an, array]`
     Array(BracketsList<Box<Self>>),
+    /// Binary operator expression.s
+    BinOp {
+        /// The left-hand side of the operator.
+        lhs: Box<Self>,
+        /// The binary operator.
+        operator: BinOp,
+        /// The right-hand side of the operator.
+        rhs: Box<Self>,
+    },
+}
+
+/// A binary operator.
+#[derive(Debug, Clone)]
+pub enum BinOp {
+    /// `|>`
+    RightPizza(RightPizzaOperator),
 }
 
 /// A chain of Effect statements.

--- a/crates/ditto-cst/src/get_span.rs
+++ b/crates/ditto-cst/src/get_span.rs
@@ -110,6 +110,7 @@ impl Expression {
             Self::True(true_keyword) => true_keyword.0.get_span(),
             Self::False(false_keyword) => false_keyword.0.get_span(),
             Self::Unit(unit_keyword) => unit_keyword.0.get_span(),
+            Self::BinOp { lhs, rhs, .. } => lhs.get_span().merge(&rhs.get_span()),
         }
     }
 }

--- a/crates/ditto-cst/src/parser/grammar.pest
+++ b/crates/ditto-cst/src/parser/grammar.pest
@@ -129,20 +129,29 @@ return_type_annotation = { colon ~ type1 } // used for function expressions only
 // Expressions
 
 expression = _ 
-  { expression_call
-  | expression_function
+  { expression_function
   | expression_match
   | expression_effect
-  | expression1
+  | expression_if
+  | expression_2
   }
 
-expression1 = _ 
+expression_2 = _ 
+  { expression_right_pipe
+  | expression_1
+  }
+
+expression_1 = _ 
+  { expression_call
+  | expression_0
+  }
+
+expression_0 = _ 
   { expression_parens 
   | expression_constructor 
   | expression_true
   | expression_false
   | expression_unit
-  | expression_if
   // It's important that keyword expressions come before variable
   | expression_variable 
   | expression_array
@@ -151,11 +160,14 @@ expression1 = _
   | expression_integer
   }
 
+// Left-associative (so needs some left recursion hacking)
+expression_right_pipe = { expression_1 ~ right_pizza ~ expression_1 ~ (right_pizza ~ expression_1)* }
+
 expression_parens = { open_paren ~ expression ~ close_paren }
 
 // No left recursion yet :(
 // https://github.com/pest-parser/pest/pull/533
-expression_call = { expression1 ~ expression_call_arguments+   }
+expression_call = { expression_0 ~ expression_call_arguments+   }
 
 expression_call_arguments = { open_paren ~ (expression ~ (comma ~ expression)* ~ comma?)?  ~ close_paren }
 
@@ -278,6 +290,8 @@ dot = ${ (WHITESPACE | LINE_COMMENT)* ~ DOT ~ HORIZONTAL_WHITESPACE? ~ LINE_COMM
 
 pipe = ${ (WHITESPACE | LINE_COMMENT)* ~ PIPE ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
 
+right_pizza = ${ (WHITESPACE | LINE_COMMENT)* ~ RIGHT_PIZZA ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+
 double_dot = ${ (WHITESPACE | LINE_COMMENT)* ~ DOUBLE_DOT ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
 
 comma = ${ (WHITESPACE | LINE_COMMENT)* ~ COMMA ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
@@ -356,6 +370,8 @@ WITH_KEYWORD = { "with" }
 DOT = { "." }
 
 PIPE = { "|" }
+
+RIGHT_PIZZA = { "|>" }
 
 DOUBLE_DOT = { ".." }
 

--- a/crates/ditto-cst/src/parser/token.rs
+++ b/crates/ditto-cst/src/parser/token.rs
@@ -5,7 +5,7 @@ use crate::{
     AsKeyword, CloseBrace, CloseBracket, CloseParen, Colon, Comma, Comment, DoKeyword, DoubleDot,
     EmptyToken, Equals, ExportsKeyword, FalseKeyword, ForeignKeyword, ImportKeyword, LeftArrow,
     LetKeyword, ModuleKeyword, OpenBrace, OpenBracket, OpenParen, Pipe, ReturnKeyword, RightArrow,
-    Span, StringToken, TrueKeyword, TypeKeyword, UnitKeyword,
+    RightPizzaOperator, Span, StringToken, TrueKeyword, TypeKeyword, UnitKeyword,
 };
 use pest::iterators::{Pair, Pairs};
 
@@ -52,6 +52,7 @@ impl_from_pair!(WithKeyword, rule = Rule::with_keyword);
 //impl_from_pair!(LetKeyword, rule = Rule::let_keyword);
 impl_from_pair!(DoKeyword, rule = Rule::do_keyword);
 impl_from_pair!(ReturnKeyword, rule = Rule::return_keyword);
+impl_from_pair!(RightPizzaOperator, rule = Rule::right_pizza);
 
 impl StringToken {
     pub(super) fn from_pairs(pairs: &mut Pairs<Rule>) -> Self {

--- a/crates/ditto-cst/src/token.rs
+++ b/crates/ditto-cst/src/token.rs
@@ -207,3 +207,7 @@ pub struct DoKeyword(pub EmptyToken);
 /// `return`
 #[derive(Debug, Clone)]
 pub struct ReturnKeyword(pub EmptyToken);
+
+/// `|>`
+#[derive(Debug, Clone)]
+pub struct RightPizzaOperator(pub EmptyToken);

--- a/crates/ditto-fmt/golden-tests/pipe_expressions.ditto
+++ b/crates/ditto-fmt/golden-tests/pipe_expressions.ditto
@@ -1,0 +1,20 @@
+module Pipe exports (..);
+
+
+long_pipe =
+    a
+    |> Some.function()  -- comment
+    -- comment
+    |> Some.other_function
+    |> Some.function_with_arguments(a, b, c)
+    |> Some.function_with_multiline_arguments(
+        -- comment
+        a,
+        b,
+        [],
+    )
+    |> (
+        a
+        |> b
+    )
+    |> done;

--- a/crates/ditto-fmt/src/has_comments.rs
+++ b/crates/ditto-fmt/src/has_comments.rs
@@ -81,6 +81,9 @@ impl HasComments for Expression {
                     || effect.has_comments()
                     || close_brace.0.has_comments()
             }
+            Self::BinOp { lhs, operator, rhs } => {
+                lhs.has_comments() || operator.has_comments() || rhs.has_comments()
+            }
         }
     }
 
@@ -101,6 +104,7 @@ impl HasComments for Expression {
             Self::Call { function, .. } => function.has_leading_comments(),
             Self::Match { match_keyword, .. } => match_keyword.0.has_leading_comments(),
             Self::Effect { do_keyword, .. } => do_keyword.0.has_leading_comments(),
+            Self::BinOp { lhs, .. } => lhs.has_leading_comments(),
         }
     }
 }
@@ -174,6 +178,19 @@ impl HasComments for Pattern {
             Self::NullaryConstructor { constructor } => constructor.has_leading_comments(),
             Self::Constructor { constructor, .. } => constructor.has_leading_comments(),
             Self::Variable { name } => name.has_leading_comments(),
+        }
+    }
+}
+
+impl HasComments for BinOp {
+    fn has_comments(&self) -> bool {
+        match self {
+            Self::RightPizza(token) => token.0.has_comments(),
+        }
+    }
+    fn has_leading_comments(&self) -> bool {
+        match self {
+            Self::RightPizza(token) => token.0.has_leading_comments(),
         }
     }
 }

--- a/crates/ditto-fmt/src/token.rs
+++ b/crates/ditto-fmt/src/token.rs
@@ -54,6 +54,7 @@ gen_empty_token_like!(gen_left_arrow, cst::LeftArrow, "<-");
 gen_empty_token_like!(gen_module_keyword, cst::ModuleKeyword, "module");
 gen_empty_token_like!(gen_do_keyword, cst::DoKeyword, "do");
 gen_empty_token_like!(gen_return_keyword, cst::ReturnKeyword, "return");
+gen_empty_token_like!(gen_right_pizza_operator, cst::RightPizzaOperator, "|>");
 gen_empty_token_like!(
     gen_close_bracket,
     cst::CloseBracket,


### PR DESCRIPTION
- [x] Add parsing logic for binary operators (initially just the `|>` operator) to `ditto-cst`
- [x] Desugar pipes as part of the "pre-AST" generation in `ditto-checker`
- [x] Extend the expression formatting logic in `ditto-fmt`
- [x] Ensure the generated JavaScript is as expected