### PR TITLE
Add `_unused` names

### DIFF
--- a/crates/ditto-ast/src/expression.rs
+++ b/crates/ditto-ast/src/expression.rs
@@ -1,4 +1,7 @@
-use crate::{FullyQualifiedName, FullyQualifiedProperName, Name, PrimType, ProperName, Span, Type};
+use crate::{
+    FullyQualifiedName, FullyQualifiedProperName, Name, PrimType, ProperName, Span, Type,
+    UnusedName,
+};
 use non_empty_vec::NonEmpty;
 use serde::{Deserialize, Serialize};
 
@@ -313,6 +316,15 @@ pub enum FunctionBinder {
         /// The name being bound.
         value: Name,
     },
+    /// An unused binder (not referenced in the body of the function).
+    Unused {
+        /// The source span for this binder.
+        span: Span,
+        /// The type of this binder.
+        binder_type: Type,
+        /// The unused name.
+        value: UnusedName,
+    },
 }
 
 impl FunctionBinder {
@@ -320,12 +332,14 @@ impl FunctionBinder {
     pub fn get_type(&self) -> Type {
         match self {
             Self::Name { binder_type, .. } => binder_type.clone(),
+            Self::Unused { binder_type, .. } => binder_type.clone(),
         }
     }
     /// Return the source [Span] for this [FunctionBinder].
     pub fn get_span(&self) -> Span {
         match self {
             Self::Name { span, .. } => *span,
+            Self::Unused { span, .. } => *span,
         }
     }
 }

--- a/crates/ditto-ast/src/expression.rs
+++ b/crates/ditto-ast/src/expression.rs
@@ -372,6 +372,13 @@ pub enum Pattern {
         /// Name to bind.
         name: Name,
     },
+    /// An unused pattern.
+    Unused {
+        /// The source span for this pattern.
+        span: Span,
+        /// The unused name.
+        unused_name: UnusedName,
+    },
 }
 
 /// A chain of Effect statements.

--- a/crates/ditto-ast/src/name.rs
+++ b/crates/ditto-ast/src/name.rs
@@ -19,6 +19,22 @@ impl From<cst::Name> for Name {
     }
 }
 
+/// An "unused name" begins with a single underscore.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct UnusedName(pub String);
+
+impl fmt::Display for UnusedName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<cst::UnusedName> for UnusedName {
+    fn from(unused_name: cst::UnusedName) -> Self {
+        Self(unused_name.0.value)
+    }
+}
+
 /// A "proper name" begins with an upper case letter.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ProperName(pub String);

--- a/crates/ditto-checker/src/module/value_declarations/mod.rs
+++ b/crates/ditto-checker/src/module/value_declarations/mod.rs
@@ -435,7 +435,12 @@ fn toposort_value_declarations(
                         .difference(
                             &parameters
                                 .iter()
-                                .map(|(param, _)| param.0.value.clone())
+                                .filter_map(|(param, _)| match param {
+                                    cst::FunctionParameter::Name(name) => {
+                                        Some(name.0.value.clone())
+                                    }
+                                    cst::FunctionParameter::Unused(_unused) => None,
+                                })
                                 .collect(),
                         )
                         .cloned()

--- a/crates/ditto-checker/src/typechecker/mod.rs
+++ b/crates/ditto-checker/src/typechecker/mod.rs
@@ -262,12 +262,27 @@ pub fn infer(env: &Env, state: &mut State, expr: pre::Expression) -> Result<Expr
                             value,
                         });
                     }
+                    pre_ast::FunctionBinder::Unused {
+                        span,
+                        type_annotation,
+                        value,
+                    } => {
+                        // REVIEW: Check this binder doesn't conflict with existing binders?
+                        let binder_type =
+                            type_annotation.unwrap_or_else(|| state.supply.fresh_type());
+
+                        binders.push(FunctionBinder::Unused {
+                            span,
+                            binder_type,
+                            value,
+                        });
+                    }
                 }
             }
             let env_values = binders
                 .clone()
                 .into_iter()
-                .map(LocalValue::from_function_binder)
+                .filter_map(LocalValue::from_function_binder)
                 .collect();
 
             let (body, unused_spans) =
@@ -756,16 +771,18 @@ struct LocalValue {
 }
 
 impl LocalValue {
-    fn from_function_binder(binder: FunctionBinder) -> Self {
-        let FunctionBinder::Name {
-            span,
-            binder_type: value_type,
-            value: name,
-        } = binder;
-        Self {
-            span,
-            value_type,
-            name,
+    fn from_function_binder(binder: FunctionBinder) -> Option<Self> {
+        match binder {
+            FunctionBinder::Name {
+                span,
+                binder_type: value_type,
+                value: name,
+            } => Some(Self {
+                span,
+                value_type,
+                name,
+            }),
+            FunctionBinder::Unused { .. } => None,
         }
     }
 }

--- a/crates/ditto-checker/src/typechecker/mod.rs
+++ b/crates/ditto-checker/src/typechecker/mod.rs
@@ -761,6 +761,11 @@ fn check_pattern(
             );
             Ok(Pattern::Variable { span, name })
         }
+        pre::Pattern::Unused { span, unused_name } => {
+            // REVIEW: check for duplicate patterns?
+
+            Ok(Pattern::Unused { span, unused_name })
+        }
     }
 }
 

--- a/crates/ditto-checker/src/typechecker/pre_ast.rs
+++ b/crates/ditto-checker/src/typechecker/pre_ast.rs
@@ -8,7 +8,7 @@ use crate::{
     result::{Result, Warnings},
     supply::Supply,
 };
-use ditto_ast::{Kind, Name, QualifiedName, QualifiedProperName, Span, Type};
+use ditto_ast::{Kind, Name, QualifiedName, QualifiedProperName, Span, Type, UnusedName};
 use ditto_cst as cst;
 use non_empty_vec::NonEmpty;
 use std::collections::hash_map;
@@ -82,6 +82,11 @@ pub enum FunctionBinder {
         span: Span,
         type_annotation: Option<Type>,
         value: Name,
+    },
+    Unused {
+        span: Span,
+        type_annotation: Option<Type>,
+        value: UnusedName,
     },
 }
 
@@ -254,8 +259,8 @@ fn convert_cst(
 
             let mut binders = Vec::new();
             if let Some(parameters) = parameters.value {
-                for (name, type_annotation) in parameters.into_iter() {
-                    let span = name.get_span();
+                for (param, type_annotation) in parameters.into_iter() {
+                    let span = param.get_span();
                     let type_annotation = if let Some(type_annotation) = type_annotation {
                         Some(check_type_annotation(
                             &env.types,
@@ -266,12 +271,22 @@ fn convert_cst(
                     } else {
                         None
                     };
-                    let value = Name::from(name);
-                    binders.push(FunctionBinder::Name {
-                        span,
-                        type_annotation,
-                        value,
-                    });
+                    match param {
+                        cst::FunctionParameter::Name(name) => {
+                            binders.push(FunctionBinder::Name {
+                                span,
+                                type_annotation,
+                                value: Name::from(name),
+                            });
+                        }
+                        cst::FunctionParameter::Unused(unused_name) => {
+                            binders.push(FunctionBinder::Unused {
+                                span,
+                                type_annotation,
+                                value: UnusedName::from(unused_name),
+                            });
+                        }
+                    }
                 }
             }
 
@@ -431,6 +446,15 @@ fn substitute_type_annotations(subst: &Substitution, expression: Expression) -> 
                         type_annotation,
                         value,
                     } => FunctionBinder::Name {
+                        span,
+                        type_annotation: type_annotation.map(|t| subst.apply_type(t)),
+                        value,
+                    },
+                    FunctionBinder::Unused {
+                        span,
+                        type_annotation,
+                        value,
+                    } => FunctionBinder::Unused {
                         span,
                         type_annotation: type_annotation.map(|t| subst.apply_type(t)),
                         value,

--- a/crates/ditto-checker/src/typechecker/pre_ast.rs
+++ b/crates/ditto-checker/src/typechecker/pre_ast.rs
@@ -536,6 +536,10 @@ pub enum Pattern {
         span: Span,
         name: Name,
     },
+    Unused {
+        span: Span,
+        unused_name: UnusedName,
+    },
 }
 
 impl From<cst::Pattern> for Pattern {
@@ -562,6 +566,10 @@ impl From<cst::Pattern> for Pattern {
             cst::Pattern::Variable { name } => Pattern::Variable {
                 span,
                 name: Name::from(name),
+            },
+            cst::Pattern::Unused { unused_name } => Pattern::Unused {
+                span,
+                unused_name: UnusedName::from(unused_name),
             },
         }
     }

--- a/crates/ditto-checker/src/typechecker/substitution.rs
+++ b/crates/ditto-checker/src/typechecker/substitution.rs
@@ -109,6 +109,15 @@ impl Substitution {
                             binder_type: self.apply(binder_type),
                             value,
                         },
+                        FunctionBinder::Unused {
+                            span,
+                            binder_type,
+                            value,
+                        } => FunctionBinder::Unused {
+                            span,
+                            binder_type: self.apply(binder_type),
+                            value,
+                        },
                     })
                     .collect(),
                 body: Box::new(self.apply_expression(body)),

--- a/crates/ditto-checker/src/typechecker/tests/function.rs
+++ b/crates/ditto-checker/src/typechecker/tests/function.rs
@@ -9,6 +9,7 @@ fn it_typechecks_as_expected() {
     assert_type!("(fn, a): Int -> fn(a) ", "(($1) -> Int, $1) -> Int");
 
     assert_type!("(x) -> x        ", "($0) -> $0");
+    assert_type!("(_x) -> 5       ", "($0) -> Int");
     assert_type!("(x: a) -> (x)   ", "(a) -> a");
     assert_type!("(x): a -> ((x)) ", "(a) -> a");
     assert_type!("(x: a): a -> x  ", "(a) -> a");

--- a/crates/ditto-checker/src/typechecker/tests/match.rs
+++ b/crates/ditto-checker/src/typechecker/tests/match.rs
@@ -5,7 +5,7 @@ use crate::{TypeError::*, Warning::*};
 fn it_typechecks_as_expected() {
     assert_type!(r#" match 5 with | x -> 2.0  "#, "Float");
     assert_type!(r#" match true with | x -> x "#, "Bool");
-    assert_type!(r#" match true with | x -> unit | y -> unit "#, "Unit");
+    assert_type!(r#" match true with | _x -> unit | _y -> unit "#, "Unit");
 }
 
 #[test]

--- a/crates/ditto-codegen-js/golden-tests/javascript/basic_expressions.ditto
+++ b/crates/ditto-codegen-js/golden-tests/javascript/basic_expressions.ditto
@@ -15,7 +15,7 @@ identity = (a: a) -> a;
 curry = (fn) -> (a) -> (b) -> fn(a, b);
 uncurry = (fn) -> (a, b) -> fn(a)(b);
 
-always = (a) -> (b) -> a;
+always = (a) -> (_b) -> a;
 select = (c, x, y) -> if c then x else y;
  
 -- REVIEW `return undefined` is redundant

--- a/crates/ditto-codegen-js/golden-tests/javascript/basic_expressions.js
+++ b/crates/ditto-codegen-js/golden-tests/javascript/basic_expressions.js
@@ -5,7 +5,7 @@ function select(c, x, y) {
   return c ? x : y;
 }
 function always(a) {
-  return b => a;
+  return _b => a;
 }
 function uncurry(fn) {
   return (a, b) => fn(a)(b);

--- a/crates/ditto-codegen-js/golden-tests/javascript/match_expressions.ditto
+++ b/crates/ditto-codegen-js/golden-tests/javascript/match_expressions.ditto
@@ -18,3 +18,8 @@ mk_five = (five) ->
 many_fields_to_array = (mf : ManyFields(a, a, a, a)): Array(a) -> 
     match mf with
     | ManyFields(a, b, c, d) -> [a, b, c, d];
+
+is_just = (maybe): Bool ->
+    match maybe with
+    | Just(_) -> true
+    | Nothing -> false;

--- a/crates/ditto-codegen-js/golden-tests/javascript/match_expressions.js
+++ b/crates/ditto-codegen-js/golden-tests/javascript/match_expressions.js
@@ -5,6 +5,15 @@ function ManyFields($0, $1, $2, $3) {
   return ["ManyFields", $0, $1, $2, $3];
 }
 const Nothing = ["Nothing"];
+function is_just(maybe) {
+  return maybe[0] === "Nothing"
+    ? false
+    : maybe[0] === "Just"
+    ? true
+    : (() => {
+        throw new Error("Pattern match error");
+      })();
+}
 function many_fields_to_array(mf) {
   return mf[0] === "ManyFields"
     ? (() => {
@@ -41,6 +50,7 @@ export {
   Just,
   ManyFields,
   Nothing,
+  is_just,
   many_fields_to_array,
   mk_five,
   with_default,

--- a/crates/ditto-codegen-js/src/convert.rs
+++ b/crates/ditto-codegen-js/src/convert.rs
@@ -212,6 +212,7 @@ fn convert_expression(
                 .into_iter()
                 .map(|binder| match binder {
                     ditto_ast::FunctionBinder::Name { value, .. } => Ident::from(value),
+                    ditto_ast::FunctionBinder::Unused { value, .. } => Ident::from(value),
                 })
                 .collect(),
             body: Box::new(ArrowFunctionBody::Expression(convert_expression(

--- a/crates/ditto-codegen-js/src/convert.rs
+++ b/crates/ditto-codegen-js/src/convert.rs
@@ -464,6 +464,9 @@ fn convert_pattern_rec(
             let assignment = (name.into(), expression);
             assignments.push(assignment)
         }
+        ditto_ast::Pattern::Unused { .. } => {
+            // noop
+        }
         ditto_ast::Pattern::LocalConstructor {
             constructor,
             arguments,

--- a/crates/ditto-codegen-js/src/convert.rs
+++ b/crates/ditto-codegen-js/src/convert.rs
@@ -516,6 +516,12 @@ impl From<ditto_ast::Name> for Ident {
     }
 }
 
+impl From<ditto_ast::UnusedName> for Ident {
+    fn from(ast_unused_name: ditto_ast::UnusedName) -> Self {
+        Self(name_string_to_ident_string(ast_unused_name.0))
+    }
+}
+
 impl From<ditto_ast::ProperName> for Ident {
     fn from(ast_proper_name: ditto_ast::ProperName) -> Self {
         Self(ast_proper_name.0)

--- a/crates/ditto-cst/src/expression.rs
+++ b/crates/ditto-cst/src/expression.rs
@@ -2,7 +2,7 @@ use crate::{
     BracketsList, CloseBrace, Colon, DoKeyword, ElseKeyword, FalseKeyword, IfKeyword, LeftArrow,
     MatchKeyword, Name, OpenBrace, Parens, ParensList, ParensList1, Pipe, QualifiedName,
     QualifiedProperName, ReturnKeyword, RightArrow, RightPizzaOperator, Semicolon, StringToken,
-    ThenKeyword, TrueKeyword, Type, UnitKeyword, WithKeyword,
+    ThenKeyword, TrueKeyword, Type, UnitKeyword, UnusedName, WithKeyword,
 };
 
 /// A value expression.
@@ -17,7 +17,7 @@ pub enum Expression {
     /// ```
     Function {
         /// The parameters to be bound and added to the scope of `body`.
-        parameters: Box<ParensList<(Name, Option<TypeAnnotation>)>>,
+        parameters: Box<ParensList<(FunctionParameter, Option<TypeAnnotation>)>>,
         /// Optional type annotation for `body`.
         return_type_annotation: Box<Option<TypeAnnotation>>,
         /// `->`
@@ -134,6 +134,15 @@ pub enum Expression {
         /// The right-hand side of the operator.
         rhs: Box<Self>,
     },
+}
+
+/// A function expression parameter.
+#[derive(Debug, Clone)]
+pub enum FunctionParameter {
+    /// A name to be bound in the body of the function.
+    Name(Name),
+    /// A name _not_ to be bound in the body of the function.
+    Unused(UnusedName),
 }
 
 /// A binary operator.

--- a/crates/ditto-cst/src/expression.rs
+++ b/crates/ditto-cst/src/expression.rs
@@ -222,6 +222,11 @@ pub enum Pattern {
         /// Name to bind.
         name: Name,
     },
+    /// An unused variable binding pattern.
+    Unused {
+        /// The unused binder.
+        unused_name: UnusedName,
+    },
 }
 
 /// `: String`

--- a/crates/ditto-cst/src/get_span.rs
+++ b/crates/ditto-cst/src/get_span.rs
@@ -17,6 +17,13 @@ impl Name {
     }
 }
 
+impl UnusedName {
+    /// Get the source span.
+    pub fn get_span(&self) -> Span {
+        self.0.get_span()
+    }
+}
+
 impl ProperName {
     /// Get the source span.
     pub fn get_span(&self) -> Span {

--- a/crates/ditto-cst/src/get_span.rs
+++ b/crates/ditto-cst/src/get_span.rs
@@ -1,6 +1,7 @@
 use crate::{
-    Brackets, Expression, ModuleName, Name, PackageName, Parens, Pattern, ProperName,
-    QualifiedName, QualifiedProperName, Span, Token, Type, TypeAnnotation, TypeCallFunction,
+    Brackets, Expression, FunctionParameter, ModuleName, Name, PackageName, Parens, Pattern,
+    ProperName, QualifiedName, QualifiedProperName, Span, Token, Type, TypeAnnotation,
+    TypeCallFunction, UnusedName,
 };
 
 impl<Value> Token<Value> {
@@ -144,6 +145,16 @@ impl Type {
                 .0
                 .get_span()
                 .merge(&return_type.get_span()),
+        }
+    }
+}
+
+impl FunctionParameter {
+    /// Get the source span.
+    pub fn get_span(&self) -> Span {
+        match self {
+            Self::Name(name) => name.get_span(),
+            Self::Unused(unused_name) => unused_name.get_span(),
         }
     }
 }

--- a/crates/ditto-cst/src/get_span.rs
+++ b/crates/ditto-cst/src/get_span.rs
@@ -206,6 +206,7 @@ impl Pattern {
                 arguments,
             } => constructor.get_span().merge(&arguments.get_span()),
             Self::Variable { name } => name.get_span(),
+            Self::Unused { unused_name } => unused_name.get_span(),
         }
     }
 }

--- a/crates/ditto-cst/src/name.rs
+++ b/crates/ditto-cst/src/name.rs
@@ -8,6 +8,10 @@ pub struct ProperName(pub StringToken);
 #[derive(Debug, Clone)]
 pub struct Name(pub StringToken);
 
+/// An "unused name" begins with a single underscore.
+#[derive(Debug, Clone)]
+pub struct UnusedName(pub StringToken);
+
 /// A package name consists of lower case letters, numbers and hyphens. It must start with a letter.
 #[derive(Debug, Clone)]
 pub struct PackageName(pub StringToken);

--- a/crates/ditto-cst/src/parser/expression.rs
+++ b/crates/ditto-cst/src/parser/expression.rs
@@ -273,6 +273,11 @@ impl Pattern {
                 let name = Name::from_pair(pattern_inner.next().unwrap());
                 Self::Variable { name }
             }
+            Rule::pattern_unused => {
+                let mut pattern_inner = pattern.into_inner();
+                let unused_name = UnusedName::from_pair(pattern_inner.next().unwrap());
+                Self::Unused { unused_name }
+            }
             other => unreachable!("{:#?} {:#?}", other, pattern.into_inner()),
         }
     }
@@ -611,7 +616,7 @@ mod tests {
             }
         );
         assert_parses!(
-            "match x with | Foo(Bar, Baz(bar, Bar)) -> 2",
+            "match x with | Foo(Bar, Baz(_, Bar), _x) -> 2",
             Expression::Match { .. }
         );
         assert_parses!(

--- a/crates/ditto-cst/src/parser/grammar.pest
+++ b/crates/ditto-cst/src/parser/grammar.pest
@@ -220,6 +220,7 @@ expression_unit = { unit_keyword }
 pattern = 
   { pattern_constructor
   | pattern_variable
+  | pattern_unused
   }
 
 pattern_constructor = { pattern_constructor_proper_name ~ pattern_constructor_arguments? }
@@ -229,6 +230,8 @@ pattern_constructor_proper_name = { qualified_proper_name }
 pattern_constructor_arguments = { open_paren ~ (pattern ~ (comma ~ pattern)* ~ comma?)?  ~ close_paren }
 
 pattern_variable = { name }
+
+pattern_unused = { unused_name }
 
 // -----------------------------------------------------------------------------
 // Names

--- a/crates/ditto-cst/src/parser/grammar.pest
+++ b/crates/ditto-cst/src/parser/grammar.pest
@@ -197,7 +197,7 @@ expression_function = { expression_function_parameters ~ return_type_annotation?
 
 expression_function_parameters = { open_paren ~ (expression_function_parameter ~ (comma ~ expression_function_parameter)* ~ comma?)?  ~ close_paren }
 
-expression_function_parameter = { name ~ type_annotation? }
+expression_function_parameter = { (name | unused_name) ~ type_annotation? }
 
 expression_if = { if_keyword ~ expression ~ then_keyword ~ expression ~ else_keyword ~ expression }
 

--- a/crates/ditto-cst/src/parser/grammar.pest
+++ b/crates/ditto-cst/src/parser/grammar.pest
@@ -21,6 +21,8 @@ expression_only = _ { SOI ~ expression ~ EOI }
 
 name_only = _ { SOI ~ name ~ EOI }
 
+unused_name_only = _ { SOI ~ unused_name ~ EOI }
+
 proper_name_only = _ { SOI ~ proper_name ~ EOI }
 
 package_name_only = _ { SOI ~ package_name ~ EOI }
@@ -242,6 +244,8 @@ qualifier = { proper_name ~ dot }
 
 name = ${ (WHITESPACE | LINE_COMMENT)* ~ NAME ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
 
+unused_name = ${ (WHITESPACE | LINE_COMMENT)* ~ UNUSED_NAME ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+
 proper_name = ${ (WHITESPACE | LINE_COMMENT)* ~ PROPER_NAME ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
 
 package_name = ${ (WHITESPACE | LINE_COMMENT)* ~ PACKAGE_NAME ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
@@ -322,6 +326,9 @@ close_brace = ${ (WHITESPACE | LINE_COMMENT)* ~ CLOSE_BRACE ~ HORIZONTAL_WHITESP
 // Atom rules (uppercase by convention)
 
 NAME = @{ LOWERCASE_LETTER ~ (LETTER | ASCII_DIGIT | "_")* } 
+
+// REVIEW: maybe this restriction on the second letter is too strict?
+UNUSED_NAME = @{ "_" ~ (LOWERCASE_LETTER ~ (LETTER | ASCII_DIGIT | "_")*)? }
 
 PROPER_NAME = @{ UPPERCASE_LETTER ~ (LETTER | ASCII_DIGIT | "_")* } 
 

--- a/crates/ditto-fmt/golden-tests/match_expressions.ditto
+++ b/crates/ditto-fmt/golden-tests/match_expressions.ditto
@@ -34,8 +34,8 @@ map_maybe = (fn, maybe) ->
 
 all_the_args = () ->
     match not_sure with
-    | Foo(a, b, c, d) -> unit
-    | Bar(Foo(a, b), b, Baz.Barrr, d) -> unit
+    | Foo(a, b, _c, d) -> unit
+    | Bar(Foo(a, b), b, Baz.Barrr, _) -> unit
     | Foo(
         -- comment
         a,

--- a/crates/ditto-fmt/src/expression.rs
+++ b/crates/ditto-fmt/src/expression.rs
@@ -1,7 +1,7 @@
 use super::{
     has_comments::HasComments,
     helpers::{group, space},
-    name::{gen_name, gen_qualified_name, gen_qualified_proper_name},
+    name::{gen_name, gen_qualified_name, gen_qualified_proper_name, gen_unused_name},
     r#type::gen_type,
     syntax::{gen_brackets_list, gen_parens, gen_parens_list, gen_parens_list1},
     token::{

--- a/crates/ditto-fmt/src/expression.rs
+++ b/crates/ditto-fmt/src/expression.rs
@@ -11,7 +11,9 @@ use super::{
         gen_string_token, gen_then_keyword, gen_true_keyword, gen_unit_keyword, gen_with_keyword,
     },
 };
-use ditto_cst::{BinOp, Effect, Expression, MatchArm, Pattern, StringToken, TypeAnnotation};
+use ditto_cst::{
+    BinOp, Effect, Expression, FunctionParameter, MatchArm, Pattern, StringToken, TypeAnnotation,
+};
 use dprint_core::formatting::{
     condition_helpers, conditions, ir_helpers, ConditionResolver, ConditionResolverContext, Info,
     PrintItems, Signal,
@@ -153,9 +155,16 @@ pub fn gen_expression(expr: Expression) -> PrintItems {
             box body,
         } => {
             let mut items = PrintItems::new();
-            items.extend(gen_parens_list(parameters, |(name, type_annotation)| {
+            items.extend(gen_parens_list(parameters, |(param, type_annotation)| {
                 let mut items = PrintItems::new();
-                items.extend(gen_name(name));
+                match param {
+                    FunctionParameter::Name(name) => {
+                        items.extend(gen_name(name));
+                    }
+                    FunctionParameter::Unused(unused_name) => {
+                        items.extend(gen_unused_name(unused_name));
+                    }
+                }
                 if let Some(type_annotation) = type_annotation {
                     items.extend(gen_type_annotation(type_annotation));
                 }

--- a/crates/ditto-fmt/src/expression.rs
+++ b/crates/ditto-fmt/src/expression.rs
@@ -291,6 +291,7 @@ fn gen_match_arm(match_arm: MatchArm) -> PrintItems {
 fn gen_pattern(pattern: Pattern) -> PrintItems {
     match pattern {
         Pattern::Variable { name } => gen_name(name),
+        Pattern::Unused { unused_name } => gen_unused_name(unused_name),
         Pattern::NullaryConstructor { constructor } => gen_qualified_proper_name(constructor),
         Pattern::Constructor {
             constructor,

--- a/crates/ditto-fmt/src/has_comments.rs
+++ b/crates/ditto-fmt/src/has_comments.rs
@@ -404,6 +404,15 @@ impl HasComments for Name {
     }
 }
 
+impl HasComments for UnusedName {
+    fn has_comments(&self) -> bool {
+        self.0.has_comments()
+    }
+    fn has_leading_comments(&self) -> bool {
+        self.0.has_leading_comments()
+    }
+}
+
 impl HasComments for ProperName {
     fn has_comments(&self) -> bool {
         self.0.has_comments()

--- a/crates/ditto-fmt/src/has_comments.rs
+++ b/crates/ditto-fmt/src/has_comments.rs
@@ -109,6 +109,22 @@ impl HasComments for Expression {
     }
 }
 
+impl HasComments for FunctionParameter {
+    fn has_comments(&self) -> bool {
+        match self {
+            Self::Name(name) => name.has_comments(),
+            Self::Unused(unused_name) => unused_name.has_comments(),
+        }
+    }
+
+    fn has_leading_comments(&self) -> bool {
+        match self {
+            Self::Name(name) => name.has_leading_comments(),
+            Self::Unused(unused_name) => unused_name.has_leading_comments(),
+        }
+    }
+}
+
 impl HasComments for Effect {
     fn has_comments(&self) -> bool {
         match self {

--- a/crates/ditto-fmt/src/has_comments.rs
+++ b/crates/ditto-fmt/src/has_comments.rs
@@ -187,6 +187,7 @@ impl HasComments for Pattern {
                 arguments,
             } => constructor.has_comments() || arguments.has_comments(),
             Self::Variable { name } => name.has_comments(),
+            Self::Unused { unused_name } => unused_name.has_comments(),
         }
     }
     fn has_leading_comments(&self) -> bool {
@@ -194,6 +195,7 @@ impl HasComments for Pattern {
             Self::NullaryConstructor { constructor } => constructor.has_leading_comments(),
             Self::Constructor { constructor, .. } => constructor.has_leading_comments(),
             Self::Variable { name } => name.has_leading_comments(),
+            Self::Unused { unused_name } => unused_name.has_leading_comments(),
         }
     }
 }

--- a/crates/ditto-fmt/src/name.rs
+++ b/crates/ditto-fmt/src/name.rs
@@ -1,5 +1,7 @@
 use super::token::{gen_dot, gen_string_token};
-use ditto_cst::{ModuleName, Name, PackageName, ProperName, QualifiedName, QualifiedProperName};
+use ditto_cst::{
+    ModuleName, Name, PackageName, ProperName, QualifiedName, QualifiedProperName, UnusedName,
+};
 use dprint_core::formatting::PrintItems;
 
 pub fn gen_module_name(module_name: ModuleName) -> PrintItems {
@@ -44,6 +46,10 @@ pub fn gen_proper_name(proper_name: ProperName) -> PrintItems {
 
 pub fn gen_name(name: Name) -> PrintItems {
     gen_string_token(name.0)
+}
+
+pub fn gen_unused_name(unused_name: UnusedName) -> PrintItems {
+    gen_string_token(unused_name.0)
 }
 
 pub fn gen_package_name(package_name: PackageName) -> PrintItems {


### PR DESCRIPTION
Currently, any unused value binders raise a warning. For example:

https://github.com/ditto-lang/ditto/blob/53a0eb49485c9ed9b3e2a57885e045bb0a4309e9/crates/ditto-checker/golden-tests/warnings/unused_function_binder.warnings#L2-L9

https://github.com/ditto-lang/ditto/blob/53a0eb49485c9ed9b3e2a57885e045bb0a4309e9/crates/ditto-checker/golden-tests/warnings/unused_pattern_binder.warnings#L2-L11

https://github.com/ditto-lang/ditto/blob/53a0eb49485c9ed9b3e2a57885e045bb0a4309e9/crates/ditto-checker/golden-tests/warnings/unused_effect_binder.warnings#L2-L12

Clearly there are legitimate reasons to ignore a binding, so there needs to be a way to suppress these warnings. Most languages (and/or linters) that I'm aware of handle this by prefixing unused variables with a `_`. 

However this is generally just a convention, as variables marked as unused (by a leading underscore) can usually still be referenced. And I'm not the only one who would prefer it if this convention was enforced by the compiler:

https://github.com/rust-lang/rust/issues/3423
https://github.com/golang/go/issues/39118

Ditto will enforce this by not treating `_unused` variables as valid expressions. In this PR this is enforced at the parser level, but that might change in future in the interest of more helpful error messages...

Note that this PR doesn't extend `Effect::Bind` with unused binders, that will be implemented as part of #46.