### PR TITLE
Add record literals and field access ⏺️ 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,7 @@ dependencies = [
  "ditto-checker",
  "ditto-cst",
  "egg",
+ "indexmap",
  "lazy_static",
  "non-empty-vec",
  "quickcheck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,7 @@ name = "ditto-ast"
 version = "0.0.1"
 dependencies = [
  "ditto-cst",
+ "indexmap",
  "non-empty-vec",
  "petgraph",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,7 @@ version = "0.0.1"
 dependencies = [
  "ditto-ast",
  "ditto-cst",
+ "indexmap",
  "lazy_static",
  "miette",
  "non-empty-vec",

--- a/crates/ditto-ast/Cargo.toml
+++ b/crates/ditto-ast/Cargo.toml
@@ -12,4 +12,5 @@ ditto-cst = { path = "../ditto-cst" }
 serde = { version = "1.0", features = ["derive"] }
 petgraph = "0.6"
 non-empty-vec = { version = "0.2", features = ["serde"] }
+indexmap = { version = "1.8", features = ["serde"] }
 #unindent = "xx"  <-- might come in useful for smart multi-line strings (like Nix)

--- a/crates/ditto-ast/src/kind.rs
+++ b/crates/ditto-ast/src/kind.rs
@@ -22,6 +22,8 @@ pub enum Kind {
         /// The kinds of the arguments this type expects.
         parameters: NonEmpty<Self>,
     },
+    /// A series of labelled types. Used for records.
+    Row,
 }
 
 impl Kind {
@@ -54,6 +56,7 @@ impl Kind {
                 output.push_str(") -> Type");
                 output
             }
+            Self::Row => String::from("Row"),
         }
     }
 }

--- a/crates/ditto-ast/src/type.rs
+++ b/crates/ditto-ast/src/type.rs
@@ -61,7 +61,7 @@ pub enum Type {
     /// { a: Int, b: Float, c: String }
     /// ```
     RecordClosed {
-        /// Can be either `Kind::Type` or `Kind::Row`.
+        /// Should be either `Kind::Type` or `Kind::Row`.
         kind: Kind,
         /// The labelled types.
         row: Row,
@@ -72,7 +72,7 @@ pub enum Type {
     /// { var | a: Int, b: Float, c: String }
     /// ```
     RecordOpen {
-        /// Can be either `Kind::Type` or `Kind::Row`.
+        /// Should be either `Kind::Type` or `Kind::Row`.
         kind: Kind,
         /// The row type variable.
         var: usize, // NOTE this should be `Kind::Row`.

--- a/crates/ditto-checker/Cargo.toml
+++ b/crates/ditto-checker/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 miette = { version = "4.6", features = ["fancy"] }
 thiserror = "1.0"
 simsearch = "0.2"
+indexmap = "1.8"
 
 [dev-dependencies]
 snapshot-test = { path = "../snapshot-test" }

--- a/crates/ditto-checker/golden-tests/type-errors/record_unification_error_0.ditto
+++ b/crates/ditto-checker/golden-tests/type-errors/record_unification_error_0.ditto
@@ -1,0 +1,4 @@
+module Test exports (..);
+
+nah = (x : { foo: Int, bar: Int, baz: Float }) ->
+    [x.foo, x.bar, x.baz];

--- a/crates/ditto-checker/golden-tests/type-errors/record_unification_error_0.error
+++ b/crates/ditto-checker/golden-tests/type-errors/record_unification_error_0.error
@@ -1,0 +1,12 @@
+
+  × types don't unify
+   ╭─[golden:1:1]
+ 1 │ module Test exports (..);
+ 2 │ 
+ 3 │ nah = (x : { foo: Int, bar: Int, baz: Float }) ->
+ 4 │     [x.foo, x.bar, x.baz];
+   ·                    ──┬──
+   ·                      ╰── here
+   ╰────
+  help: expected Int
+        got Float

--- a/crates/ditto-checker/golden-tests/type-errors/row_unification_error_0.ditto
+++ b/crates/ditto-checker/golden-tests/type-errors/row_unification_error_0.ditto
@@ -1,0 +1,3 @@
+module Test exports (..);
+
+foo = (r : { r | foo: Unit}): r -> unit;

--- a/crates/ditto-checker/golden-tests/type-errors/row_unification_error_0.error
+++ b/crates/ditto-checker/golden-tests/type-errors/row_unification_error_0.error
@@ -1,0 +1,11 @@
+
+  × kinds don't unify
+   ╭─[golden:1:1]
+ 1 │ module Test exports (..);
+ 2 │ 
+ 3 │ foo = (r : { r | foo: Unit}): r -> unit;
+   ·                               ┬
+   ·                               ╰── here
+   ╰────
+  help: expected Type
+        got Row

--- a/crates/ditto-checker/golden-tests/type-errors/row_unification_error_1.ditto
+++ b/crates/ditto-checker/golden-tests/type-errors/row_unification_error_1.ditto
@@ -1,0 +1,5 @@
+module Test exports (..);
+
+type ExtensibleProps(r) = ExtensibleProps({ r | foo: Int });
+
+type BadExtension = Bad(ExtensibleProps(Int));

--- a/crates/ditto-checker/golden-tests/type-errors/row_unification_error_1.error
+++ b/crates/ditto-checker/golden-tests/type-errors/row_unification_error_1.error
@@ -1,0 +1,12 @@
+
+  × kinds don't unify
+   ╭─[golden:2:1]
+ 2 │ 
+ 3 │ type ExtensibleProps(r) = ExtensibleProps({ r | foo: Int });
+ 4 │ 
+ 5 │ type BadExtension = Bad(ExtensibleProps(Int));
+   ·                                         ─┬─
+   ·                                          ╰── here
+   ╰────
+  help: expected Row
+        got Type

--- a/crates/ditto-checker/src/kindchecker/substitution.rs
+++ b/crates/ditto-checker/src/kindchecker/substitution.rs
@@ -36,6 +36,7 @@ impl Substitution {
                 },
             },
             Kind::Type => Kind::Type,
+            Kind::Row => Kind::Row,
         }
     }
     pub fn apply_type(&self, ast_type: Type) -> Type {
@@ -86,6 +87,27 @@ impl Substitution {
                 source_value,
             },
             Type::PrimConstructor(prim_type) => Type::PrimConstructor(prim_type),
+            Type::RecordClosed { kind, row } => Type::RecordClosed {
+                kind: self.apply(kind),
+                row: row
+                    .into_iter()
+                    .map(|(label, t)| (label, self.apply_type(t)))
+                    .collect(),
+            },
+            Type::RecordOpen {
+                kind,
+                var,
+                row,
+                source_name,
+            } => Type::RecordOpen {
+                kind: self.apply(kind),
+                var,
+                source_name,
+                row: row
+                    .into_iter()
+                    .map(|(label, t)| (label, self.apply_type(t)))
+                    .collect(),
+            },
         }
     }
     pub fn apply_constructor(&self, constructor: ModuleConstructor) -> ModuleConstructor {

--- a/crates/ditto-checker/src/module/imports/mod.rs
+++ b/crates/ditto-checker/src/module/imports/mod.rs
@@ -546,5 +546,26 @@ fn requalify_type(ast_type: Type, package_name: &PackageName) -> Type {
             return_type: Box::new(requalify_type(return_type, package_name)),
         },
         Type::PrimConstructor(prim_type) => Type::PrimConstructor(prim_type),
+        Type::RecordClosed { kind, row } => Type::RecordClosed {
+            kind,
+            row: row
+                .into_iter()
+                .map(|(label, t)| (label, requalify_type(t, package_name)))
+                .collect(),
+        },
+        Type::RecordOpen {
+            kind,
+            var,
+            source_name,
+            row,
+        } => Type::RecordOpen {
+            kind,
+            var,
+            source_name,
+            row: row
+                .into_iter()
+                .map(|(label, t)| (label, requalify_type(t, package_name)))
+                .collect(),
+        },
     }
 }

--- a/crates/ditto-checker/src/module/tests/mod.rs
+++ b/crates/ditto-checker/src/module/tests/mod.rs
@@ -1,1 +1,16 @@
 pub(crate) mod macros;
+
+#[test]
+fn dunno_where_to_put_these() {
+    macros::assert_module_ok!(
+        r#"
+        module Test exports (..);
+
+        always = (a) -> (b) -> a;
+        five: Int = always(5)(true);
+
+        always_five: (a) -> Int = always(5);
+        another_five: Int = always_five(unit);
+        "#
+    );
+}

--- a/crates/ditto-checker/src/module/type_declarations/mod.rs
+++ b/crates/ditto-checker/src/module/type_declarations/mod.rs
@@ -631,6 +631,24 @@ fn toposort_type_declarations(
                 }
             }
             Variable { .. } => {}
+            RecordClosed(braces) => {
+                if let Some(ref fields) = braces.value {
+                    fields
+                        .iter()
+                        .for_each(|cst::RecordTypeField { value, .. }| {
+                            get_connected_nodes_type_rec(value, nodes, accum);
+                        })
+                }
+            }
+            RecordOpen(braces) => {
+                braces
+                    .value
+                    .2
+                    .iter()
+                    .for_each(|cst::RecordTypeField { value, .. }| {
+                        get_connected_nodes_type_rec(value, nodes, accum);
+                    })
+            }
         };
     }
 }

--- a/crates/ditto-checker/src/module/type_declarations/tests/acyclic.rs
+++ b/crates/ditto-checker/src/module/type_declarations/tests/acyclic.rs
@@ -1,5 +1,5 @@
 use super::macros::*;
-use crate::{module::tests::macros::assert_module_ok, TypeError::*};
+use crate::TypeError::*;
 
 #[test]
 fn it_kindchecks_as_expected() {
@@ -51,16 +51,18 @@ fn it_kindchecks_as_expected() {
     assert_type_declaration!("type Unknown", ("Unknown", "Type"), []);
     assert_type_declaration!("type Unknown(a)", ("Unknown", "($1) -> Type"), []);
 
-    assert_module_ok!(
-        r#"
-        module Test exports (..);
-
-        always = (a) -> (b) -> a;
-        five: Int = always(5)(true);
-
-        always_five: (a) -> Int = always(5);
-        another_five: Int = always_five(unit);
-        "#
+    assert_type_declaration!(
+        "type Props = Props({ foo: Int })",
+        ("Props", "Type"),
+        [("Props", "({ foo: Int }) -> Props")]
+    );
+    assert_type_declaration!(
+        "type ExtensibleProps(r) = ExtensibleProps({ r | foo: Int })",
+        ("ExtensibleProps", "(Row) -> Type"),
+        [(
+            "ExtensibleProps",
+            "({ r$0 | foo: Int }) -> ExtensibleProps(r$0)"
+        )]
     );
 }
 

--- a/crates/ditto-checker/src/module/value_declarations/mod.rs
+++ b/crates/ditto-checker/src/module/value_declarations/mod.rs
@@ -482,6 +482,16 @@ fn toposort_value_declarations(
                     })
                 }
             }
+            Expression::Record(fields) => {
+                if let Some(ref fields) = fields.value {
+                    fields.iter().for_each(|cst::RecordField { value, .. }| {
+                        get_connected_nodes_rec(value, nodes, accum);
+                    })
+                }
+            }
+            Expression::RecordAccess { target, .. } => {
+                get_connected_nodes_rec(target, nodes, accum);
+            }
             Expression::Parens(parens) => {
                 get_connected_nodes_rec(&parens.value, nodes, accum);
             }

--- a/crates/ditto-checker/src/typechecker/coverage/mod.rs
+++ b/crates/ditto-checker/src/typechecker/coverage/mod.rs
@@ -256,14 +256,19 @@ fn constructors_for_type(pattern_type: &Type, env_constructors: &EnvConstructors
                             ..
                         }) = get_function_return_type(&constructor_type)
                         {
-                            let type_subst: HashMap<Type, Type> = generic_arguments
+                            // NOTE using an association list because we can't
+                            // derive `Hash` for `Type`
+                            let type_subst: Vec<(Type, Type)> = generic_arguments
                                 .into_iter()
                                 .zip(specific_arguments.clone())
                                 .collect();
+
                             constructor_arguments = constructor_arguments
                                 .into_iter()
                                 .map(|arg| {
-                                    if let Some(t) = type_subst.get(&arg).cloned() {
+                                    if let Some((_, t)) =
+                                        type_subst.iter().find(|(t, _)| *t == arg).cloned()
+                                    {
                                         t
                                     } else {
                                         arg

--- a/crates/ditto-checker/src/typechecker/env.rs
+++ b/crates/ditto-checker/src/typechecker/env.rs
@@ -123,7 +123,6 @@ pub enum EnvConstructor {
         constructor_scheme: Scheme,
         constructor: ProperName,
     },
-    #[allow(dead_code)]
     ImportedConstructor {
         constructor_scheme: Scheme,
         constructor: FullyQualifiedProperName,

--- a/crates/ditto-checker/src/typechecker/tests/function.rs
+++ b/crates/ditto-checker/src/typechecker/tests/function.rs
@@ -30,6 +30,8 @@ fn it_typechecks_as_expected() {
         "($2) -> (a, String) -> String"
     );
 
+    assert_type!("(a: a) -> ((b : b) -> b)(a)", "(a) -> a");
+
     // REVIEW is this legit?
     assert_type!(
         "(fn: (a) -> a): ((a) -> a) -> ((x) -> x)",

--- a/crates/ditto-checker/src/typechecker/tests/mod.rs
+++ b/crates/ditto-checker/src/typechecker/tests/mod.rs
@@ -8,6 +8,7 @@ mod function;
 mod int;
 pub(self) mod macros;
 mod r#match;
+mod records;
 mod right_pipe;
 mod string;
 mod unit;

--- a/crates/ditto-checker/src/typechecker/tests/records.rs
+++ b/crates/ditto-checker/src/typechecker/tests/records.rs
@@ -1,0 +1,123 @@
+use super::macros::*;
+use crate::TypeError::*;
+use ditto_ast as ast;
+
+#[test]
+fn it_typechecks_as_expected() {
+    assert_type!("{}", "{}");
+    assert_type!("{ foo = true }", "{ foo: Bool }");
+    assert_type!("{ foo = {}, bar = [] }", "{ foo: {}, bar: Array($0) }");
+
+    assert_type!("(x) -> x.foo", "({ $1 | foo: $2 }) -> $2");
+    assert_type!(
+        "(x: { r | foo: Int }) -> x.foo",
+        "({ r | foo: Int }) -> Int"
+    );
+
+    assert_type!("(x) -> x.foo.bar", "({ $3 | foo: { $1 | bar: $2 } }) -> $2");
+    assert_type!(
+        "(x) -> [x.foo, x.bar, x.baz]",
+        "({ $8 | foo: $7, bar: $7, baz: $7 }) -> Array($7)"
+    );
+    assert_type!(
+        "(x : { r | foo: Int, bar: Int, baz: Int }) -> [x.foo, x.bar, x.baz]",
+        "({ r | foo: Int, bar: Int, baz: Int }) -> Array(Int)"
+    );
+    assert_type!(
+        "(x : { foo: Int, bar: Int, baz: Int }) -> [x.foo, x.bar, x.baz]",
+        "({ foo: Int, bar: Int, baz: Int }) -> Array(Int)"
+    );
+    assert_type!("((r) -> r.foo)({ foo = 5 })", "Int");
+    assert_type!("((r : { r | foo: Bool }) -> r.foo)({ foo = true })", "Bool");
+}
+
+#[test]
+fn it_errors_as_expected() {
+    assert_type_error!("(x: { r | foo: Int }) -> x.bar", TypesNotEqual { .. });
+
+    assert_type_error!(
+        "(x: { r | foo: Int }): r -> unit",
+        KindsNotEqual {
+            expected: ast::Kind::Type,
+            actual: ast::Kind::Row,
+            ..
+        }
+    );
+    assert_type_error!(
+        "(): { foo: Int} -> { bar = 5 }",
+        TypesNotEqual {
+            expected: ast::Type::RecordClosed { .. },
+            actual: ast::Type::RecordClosed { .. },
+            ..
+        }
+    );
+    assert_type_error!(
+        "(): { r | foo: Int } -> { foo = 5 }",
+        TypesNotEqual {
+            expected: ast::Type::RecordOpen { .. },
+            actual: ast::Type::RecordClosed { .. },
+            ..
+        }
+    );
+    assert_type_error!(
+        "(r : { r | foo: Bool }) : { x | foo: Bool } -> r",
+        TypesNotEqual { .. }
+    );
+    assert_type_error!(
+        "(x : { foo: Int, bar: Int, baz: Float }) -> [x.foo, x.bar, x.baz]",
+        TypesNotEqual { .. }
+    );
+}
+
+#[test]
+fn it_typechecks_a_complex_module() {
+    let ast::Module {
+        constructors,
+        values,
+        ..
+    } = crate::module::tests::macros::assert_module_ok!(
+        r#"
+        module Test exports (..);
+
+        type ExtendMe(r) = ExtendMe({ r | foo: Int });
+
+        extended0 = ExtendMe({ foo = 2 });
+        extended1 = ExtendMe({ foo = 2, bar = 3 });
+        extended2 : ExtendMe({ bar : Int, baz: Int }) = ExtendMe({ foo = 2, bar = 3, baz = 5 });
+        -- extended3 = ExtendMe({ bar = 2 });   ERROR
+
+        unwrap_extend_me0 = (e): { r | foo : Int } -> match e with | ExtendMe(r) -> r;
+        unwrap_extend_me1 = (e): { foo : Int } -> match e with | ExtendMe(r) -> r;
+        get_foo = (e): Int -> unwrap_extend_me0(e).foo;
+
+        type ExtendedOpen(r) = Open(ExtendMe({ r | bar: Int }));
+
+        extended_open0 : ExtendedOpen({}) = Open(ExtendMe({ foo = 1, bar = 2}));
+        extended_open1 : ExtendedOpen({ baz: Unit }) = Open(ExtendMe({ foo = 1, bar = 2, baz = unit }));
+
+        type ExtendedClosed = Closed(ExtendedOpen({ baz: Int }));
+        extended_closed : ExtendedClosed = Closed(Open(ExtendMe({
+            foo = 1,
+            bar = 2,
+            baz = 3,
+        })));
+        "#
+    );
+    assert_eq!(
+        constructors
+            .get(&ast::proper_name!("ExtendMe"))
+            .unwrap()
+            .get_type()
+            .debug_render(),
+        "({ r | foo: Int }) -> ExtendMe(r)"
+    );
+    assert_eq!(
+        values
+            .get(&ast::name!("extended2"))
+            .unwrap()
+            .expression
+            .get_type()
+            .debug_render(),
+        "ExtendMe(#{ bar: Int, baz: Int })"
+    );
+}

--- a/crates/ditto-cli/fixtures/javascript-project/package.json
+++ b/crates/ditto-cli/fixtures/javascript-project/package.json
@@ -3,6 +3,6 @@
   "type": "module",
   "workspaces": ["packages/*"],
   "scripts": {
-    "test": "node --input-type=module --eval \"import * as D from './dist/D.js'; console.log(D)\""
+    "test": "node --eval \"import * as D from './dist/D.js'; console.log(D)\""
   }
 }

--- a/crates/ditto-codegen-js/Cargo.toml
+++ b/crates/ditto-codegen-js/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 ditto-ast = { path = "../ditto-ast" }
 lazy_static = "1.4"
 egg = "0.7"
+indexmap = "1.8"
 
 [dev-dependencies]
 ditto-checker = { path = "../ditto-checker" }

--- a/crates/ditto-codegen-js/golden-tests/javascript/effect_expressions.js
+++ b/crates/ditto-codegen-js/golden-tests/javascript/effect_expressions.js
@@ -27,21 +27,17 @@ function get_names() {
 function get_names_from_result(res) {
   return () => {
     get_name();
-    return (
-      res[0] === "Ok"
-        ? (() => {
-            const a = res[1];
-            return always(a, get_names);
-          })()
-        : res[0] === "Err"
-        ? (() => {
-            const e = res[1];
-            return always(e, get_names);
-          })()
-        : (() => {
-            throw new Error("Pattern match error");
-          })()
-    )();
+    return (() => {
+      if (res[0] === "Ok") {
+        const a = res[1];
+        return always(a, get_names);
+      }
+      if (res[0] === "Err") {
+        const e = res[1];
+        return always(e, get_names);
+      }
+      throw new Error("Pattern match error");
+    })()();
   };
 }
 export {

--- a/crates/ditto-codegen-js/golden-tests/javascript/match_expressions.ditto
+++ b/crates/ditto-codegen-js/golden-tests/javascript/match_expressions.ditto
@@ -38,3 +38,14 @@ effect_arms = (maybe) ->
     match maybe with
     | Just(a) -> do { return a }
     | Nothing -> do { return 5 };
+
+type ABC =
+    | A
+    | B
+    | C;
+
+to_string = (abc) ->
+    match abc with
+    | A -> "A"
+    | B -> "C"
+    | C -> "C";

--- a/crates/ditto-codegen-js/golden-tests/javascript/match_expressions.js
+++ b/crates/ditto-codegen-js/golden-tests/javascript/match_expressions.js
@@ -1,3 +1,6 @@
+const A = ["A"];
+const B = ["B"];
+const C = ["C"];
 function Just($0) {
   return ["Just", $0];
 }
@@ -5,6 +8,18 @@ function ManyFields($0, $1, $2, $3) {
   return ["ManyFields", $0, $1, $2, $3];
 }
 const Nothing = ["Nothing"];
+function to_string(abc) {
+  if (abc[0] === "A") {
+    return "A";
+  }
+  if (abc[0] === "B") {
+    return "C";
+  }
+  if (abc[0] === "C") {
+    return "C";
+  }
+  throw new Error("Pattern match error");
+}
 function effect_arms(maybe) {
   if (maybe[0] === "Just") {
     const a = maybe[1];
@@ -20,22 +35,20 @@ function very_function_arms(maybe) {
     const a = maybe[1];
     return b => c => d => [a, b, c];
   }
-  return maybe[0] === "Nothing"
-    ? b => c => d => [1, b, c]
-    : (() => {
-        throw new Error("Pattern match error");
-      })();
+  if (maybe[0] === "Nothing") {
+    return b => c => d => [1, b, c];
+  }
+  throw new Error("Pattern match error");
 }
 function function_arms(maybe) {
   if (maybe[0] === "Just") {
     const a = maybe[1];
     return (b, c) => [a, b, c];
   }
-  return maybe[0] === "Nothing"
-    ? (b, c) => [1, b, c]
-    : (() => {
-        throw new Error("Pattern match error");
-      })();
+  if (maybe[0] === "Nothing") {
+    return (b, c) => [1, b, c];
+  }
+  throw new Error("Pattern match error");
 }
 function is_just(maybe) {
   if (maybe[0] === "Just") {
@@ -73,6 +86,9 @@ function with_default(maybe, $default) {
   throw new Error("Pattern match error");
 }
 export {
+  A,
+  B,
+  C,
   Just,
   ManyFields,
   Nothing,
@@ -81,6 +97,7 @@ export {
   is_just,
   many_fields_to_array,
   mk_five,
+  to_string,
   very_function_arms,
   with_default,
 };

--- a/crates/ditto-codegen-js/golden-tests/javascript/objects.ditto
+++ b/crates/ditto-codegen-js/golden-tests/javascript/objects.ditto
@@ -1,0 +1,17 @@
+module Test exports (..);
+
+empty_object : {} = {};
+
+just_object_things = { yep = true, huh = unit, why = () -> {} };
+
+-- FIXME: parsing this is hilariously slow
+very_nested = { a = { b = { c = { d = [] }}}};
+
+d = very_nested.a.b.c.d;
+
+get_foo = (x : { r | foo: a }) -> x.foo;
+mk_has_foo = (a) -> { foo = a };
+foo = mk_has_foo(true).foo;
+
+pure_object = () -> {};
+do_object = do { return {} };

--- a/crates/ditto-codegen-js/golden-tests/javascript/objects.js
+++ b/crates/ditto-codegen-js/golden-tests/javascript/objects.js
@@ -1,0 +1,28 @@
+function do_object() {
+  return {};
+}
+function pure_object() {
+  return {};
+}
+function mk_has_foo(a) {
+  return { foo: a };
+}
+const foo = mk_has_foo(true)["foo"];
+function get_foo(x) {
+  return x["foo"];
+}
+const very_nested = { a: { b: { c: { d: [] } } } };
+const d = very_nested["a"]["b"]["c"]["d"];
+const just_object_things = { yep: true, huh: undefined, why: () => ({}) };
+const empty_object = {};
+export {
+  d,
+  do_object,
+  empty_object,
+  foo,
+  get_foo,
+  just_object_things,
+  mk_has_foo,
+  pure_object,
+  very_nested,
+};

--- a/crates/ditto-codegen-js/src/ast.rs
+++ b/crates/ditto-codegen-js/src/ast.rs
@@ -159,10 +159,14 @@ pub enum Expression {
         lhs: Box<Self>,
         rhs: Box<Self>,
     },
-    IndexAccess {
-        target: Box<Self>,
-        index: Box<Self>,
-    },
+    /// ```javascript
+    /// target[index]
+    /// ```
+    IndexAccess { target: Box<Self>, index: Box<Self> },
+    /// ```javascript
+    /// { "key": value }
+    /// ```
+    Object(indexmap::IndexMap<String, Self>),
 }
 
 /// A binary operator.

--- a/crates/ditto-codegen-js/src/convert.rs
+++ b/crates/ditto-codegen-js/src/convert.rs
@@ -409,6 +409,23 @@ pub(crate) fn convert_expression(
                 body: Box::new(ArrowFunctionBody::Block(block)),
             }
         }
+        ditto_ast::Expression::RecordAccess {
+            box target, label, ..
+        } => {
+            let target = convert_expression(imported_module_idents, target);
+            let index = Expression::String(label.0);
+            Expression::IndexAccess {
+                target: Box::new(target),
+                index: Box::new(index),
+            }
+        }
+        ditto_ast::Expression::Record { fields, .. } => {
+            let entries = fields
+                .into_iter()
+                .map(|(name, expr)| (name.0, convert_expression(imported_module_idents, expr)))
+                .collect();
+            Expression::Object(entries)
+        }
     }
 }
 

--- a/crates/ditto-codegen-js/src/lib.rs
+++ b/crates/ditto-codegen-js/src/lib.rs
@@ -56,10 +56,9 @@ mod tests {
             .spawn()
             .unwrap();
 
-        let child_stdin = child.stdin.as_mut().unwrap();
-        child_stdin.write_all(text.as_bytes()).unwrap();
-        // Close stdin to finish and avoid indefinite blocking
-        drop(child_stdin);
+        let mut stdin = child.stdin.take().unwrap();
+        stdin.write_all(text.as_bytes()).unwrap();
+        drop(stdin);
 
         let output = child.wait_with_output().unwrap();
         assert!(output.status.success());

--- a/crates/ditto-codegen-js/src/optimize/mod.rs
+++ b/crates/ditto-codegen-js/src/optimize/mod.rs
@@ -79,6 +79,10 @@ pub enum Expression {
         op: ast::Operator,
         children: [Id; 2],
     },
+    Object {
+        keys: Vec<String>,
+        values: Vec<Id>,
+    },
     // Blocks
     BlockExpression {
         children: [Id; 2],
@@ -118,6 +122,7 @@ impl egg::Language for Expression {
             (Self::ArrowFunctionIdentity { .. }, Self::ArrowFunctionIdentity { .. }) => true,
             (Self::IndexAccess { .. }, Self::IndexAccess { .. }) => true,
             (Self::Operator { op: x, .. }, Self::Operator { op: y, .. }) => x == y,
+            (Self::Object { .. }, Self::Object { .. }) => true, // check entries.len ?
             // Blocks
             (Self::BlockExpression { .. }, Self::BlockExpression { .. }) => true,
             (Self::BlockReturn { .. }, Self::BlockReturn { .. }) => true,
@@ -148,6 +153,7 @@ impl egg::Language for Expression {
             Self::Call { children } => children,
             Self::IndexAccess { children } => children,
             Self::Operator { children, .. } => children,
+            Self::Object { values, .. } => values,
             // Blocks
             Self::BlockExpression { children } => children,
             Self::BlockConstAssignment { children, .. } => children,
@@ -177,6 +183,7 @@ impl egg::Language for Expression {
             Self::Call { children } => children,
             Self::IndexAccess { children } => children,
             Self::Operator { children, .. } => children,
+            Self::Object { values, .. } => values,
             // Blocks
             Self::BlockConstAssignment { children, .. } => children,
             Self::BlockExpression { children } => children,
@@ -298,6 +305,16 @@ fn ast_expr_to_rec_expr(ast_expr: &ast::Expression, rec_expr: &mut RecExpr) -> I
             };
             rec_expr.add(node)
         }
+        ast::Expression::Object(entries) => {
+            let mut keys = Vec::with_capacity(entries.len());
+            let mut values = Vec::with_capacity(entries.len());
+            for (key, value) in entries {
+                keys.push(key.clone());
+                values.push(ast_expr_to_rec_expr(value, rec_expr));
+            }
+            let node = Expression::Object { keys, values };
+            rec_expr.add(node)
+        }
         // Leaves
         ast::Expression::True => rec_expr.add(Expression::True),
         ast::Expression::False => rec_expr.add(Expression::False),
@@ -384,6 +401,7 @@ fn unbuild_rec_expr(expr: &Expression, rec_expr: &RecExpr) -> BlockOrExpression 
         | Expression::ArrowFunctionIdentity { .. }
         | Expression::IndexAccess { .. }
         | Expression::Operator { .. }
+        | Expression::Object { .. }
         | Expression::True
         | Expression::False
         | Expression::Undefined
@@ -487,6 +505,14 @@ fn rec_expr_to_ast_expr(expr: &Expression, rec_expr: &RecExpr) -> ast::Expressio
             lhs: Box::new(rec_expr_to_ast_expr(&rec_expr[*lhs_id], rec_expr)),
             rhs: Box::new(rec_expr_to_ast_expr(&rec_expr[*rhs_id], rec_expr)),
         },
+        Expression::Object { keys, values } => {
+            let mut entries = indexmap::IndexMap::with_capacity(keys.len());
+            for (key, value_id) in keys.iter().zip(values) {
+                let value = rec_expr_to_ast_expr(&rec_expr[*value_id], rec_expr);
+                entries.insert(key.clone(), value);
+            }
+            ast::Expression::Object(entries)
+        }
         // Leaves
         Expression::True => ast::Expression::True,
         Expression::False => ast::Expression::False,
@@ -564,6 +590,7 @@ fn rec_expr_to_ast_block(expr: &Expression, rec_expr: &RecExpr) -> ast::Block {
         | Expression::ArrowFunctionIdentity { .. }
         | Expression::IndexAccess { .. }
         | Expression::Operator { .. }
+        | Expression::Object { .. }
         | Expression::True
         | Expression::False
         | Expression::Undefined
@@ -625,7 +652,7 @@ mod test {
 
     impl ast::Expression {
         fn arbitrary_stacksafe(g: &mut Gen, depth: usize) -> Self {
-            if depth <= 0 {
+            if depth == 0 {
                 // Generate leaf
                 let variable = Self::Variable(ast::Ident::arbitrary(g));
                 let number = Self::Number(String::arbitrary(g));
@@ -650,6 +677,7 @@ mod test {
                         3, // Array
                         4, // Operator
                         5, // IndexAccess
+                        6, // IndexAccess
                     ])
                     .cloned()
                     .unwrap();
@@ -696,6 +724,22 @@ mod test {
                         target: Box::new(Self::arbitrary_stacksafe(g, depth - 1)),
                         index: Box::new(Self::arbitrary_stacksafe(g, depth - 1)),
                     },
+                    6 => Self::Object({
+                        let mut entries = indexmap::IndexMap::with_capacity(3);
+                        entries.insert(
+                            String::arbitrary(g),
+                            Self::arbitrary_stacksafe(g, depth - 1),
+                        );
+                        entries.insert(
+                            String::arbitrary(g),
+                            Self::arbitrary_stacksafe(g, depth - 1),
+                        );
+                        entries.insert(
+                            String::arbitrary(g),
+                            Self::arbitrary_stacksafe(g, depth - 1),
+                        );
+                        entries
+                    }),
                     _ => unreachable!(),
                 }
             }
@@ -705,7 +749,7 @@ mod test {
     impl ast::Block {
         fn arbitrary_stacksafe(g: &mut Gen, depth: usize) -> Self {
             // Generate leaf
-            if depth <= 0 {
+            if depth == 0 {
                 let return_expr = Self::Return(Some(ast::Expression::arbitrary_stacksafe(g, 0)));
                 let throw = Self::Throw(String::arbitrary(g));
                 g.choose(&[throw, return_expr, Self::Return(None)])

--- a/crates/ditto-codegen-js/tests/node_execution_test.rs
+++ b/crates/ditto-codegen-js/tests/node_execution_test.rs
@@ -12,7 +12,6 @@ fn node_can_execute_generated_code() -> io::Result<()> {
         if let Some("js") = path.extension().and_then(OsStr::to_str) {
             let output = Command::new("node")
                 .args([
-                    "--input-type=module",
                     "--eval",
                     &format!(
                         "import * as x from '{path}';console.log(x)",

--- a/crates/ditto-cst/src/expression.rs
+++ b/crates/ditto-cst/src/expression.rs
@@ -1,5 +1,5 @@
 use crate::{
-    BracesList, BracketsList, CloseBrace, Colon, DoKeyword, ElseKeyword, Equals, FalseKeyword,
+    BracesList, BracketsList, CloseBrace, Colon, DoKeyword, Dot, ElseKeyword, Equals, FalseKeyword,
     IfKeyword, LeftArrow, MatchKeyword, Name, OpenBrace, Parens, ParensList, ParensList1, Pipe,
     QualifiedName, QualifiedProperName, ReturnKeyword, RightArrow, RightPizzaOperator, Semicolon,
     StringToken, ThenKeyword, TrueKeyword, Type, UnitKeyword, UnusedName, WithKeyword,
@@ -135,6 +135,15 @@ pub enum Expression {
         operator: BinOp,
         /// The right-hand side of the operator.
         rhs: Box<Self>,
+    },
+    /// `foo.bar`
+    RecordAccess {
+        /// The record expression being accesses.
+        target: Box<Self>,
+        /// `.`
+        dot: Dot,
+        /// Label of the field being accessed.
+        label: Name,
     },
 }
 

--- a/crates/ditto-cst/src/expression.rs
+++ b/crates/ditto-cst/src/expression.rs
@@ -1,8 +1,8 @@
 use crate::{
-    BracketsList, CloseBrace, Colon, DoKeyword, ElseKeyword, FalseKeyword, IfKeyword, LeftArrow,
-    MatchKeyword, Name, OpenBrace, Parens, ParensList, ParensList1, Pipe, QualifiedName,
-    QualifiedProperName, ReturnKeyword, RightArrow, RightPizzaOperator, Semicolon, StringToken,
-    ThenKeyword, TrueKeyword, Type, UnitKeyword, UnusedName, WithKeyword,
+    BracesList, BracketsList, CloseBrace, Colon, DoKeyword, ElseKeyword, Equals, FalseKeyword,
+    IfKeyword, LeftArrow, MatchKeyword, Name, OpenBrace, Parens, ParensList, ParensList1, Pipe,
+    QualifiedName, QualifiedProperName, ReturnKeyword, RightArrow, RightPizzaOperator, Semicolon,
+    StringToken, ThenKeyword, TrueKeyword, Type, UnitKeyword, UnusedName, WithKeyword,
 };
 
 /// A value expression.
@@ -125,6 +125,8 @@ pub enum Expression {
     Float(StringToken),
     /// `[this, is, an, array]`
     Array(BracketsList<Box<Self>>),
+    /// `{ this = "is a record" }`
+    Record(BracesList<RecordField>),
     /// Binary operator expression.s
     BinOp {
         /// The left-hand side of the operator.
@@ -134,6 +136,17 @@ pub enum Expression {
         /// The right-hand side of the operator.
         rhs: Box<Self>,
     },
+}
+
+/// A labelled expression within a record.
+#[derive(Debug, Clone)]
+pub struct RecordField {
+    /// The field label.
+    pub label: Name,
+    /// `=`
+    pub equals: Equals,
+    /// The value to be associated with the `label`.
+    pub value: Box<Expression>,
 }
 
 /// A function expression parameter.

--- a/crates/ditto-cst/src/get_span.rs
+++ b/crates/ditto-cst/src/get_span.rs
@@ -147,6 +147,7 @@ impl Type {
                 .0
                 .get_span()
                 .merge(&return_type.get_span()),
+            Self::Record(braces) => braces.get_span(),
         }
     }
 }

--- a/crates/ditto-cst/src/get_span.rs
+++ b/crates/ditto-cst/src/get_span.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Brackets, Expression, FunctionParameter, ModuleName, Name, PackageName, Parens, Pattern,
-    ProperName, QualifiedName, QualifiedProperName, Span, Token, Type, TypeAnnotation,
+    Braces, Brackets, Expression, FunctionParameter, ModuleName, Name, PackageName, Parens,
+    Pattern, ProperName, QualifiedName, QualifiedProperName, Span, Token, Type, TypeAnnotation,
     TypeCallFunction, UnusedName,
 };
 
@@ -115,6 +115,7 @@ impl Expression {
             Self::Int(int_token) => int_token.get_span(),
             Self::Float(float_token) => float_token.get_span(),
             Self::Array(brackets) => brackets.get_span(),
+            Self::Record(braces) => braces.get_span(),
             Self::True(true_keyword) => true_keyword.0.get_span(),
             Self::False(false_keyword) => false_keyword.0.get_span(),
             Self::Unit(unit_keyword) => unit_keyword.0.get_span(),
@@ -193,6 +194,15 @@ impl<T> Brackets<T> {
             .0
             .get_span()
             .merge(&self.close_bracket.0.get_span())
+    }
+}
+impl<T> Braces<T> {
+    /// Get the source span.
+    pub fn get_span(&self) -> Span {
+        self.open_brace
+            .0
+            .get_span()
+            .merge(&self.close_brace.0.get_span())
     }
 }
 

--- a/crates/ditto-cst/src/get_span.rs
+++ b/crates/ditto-cst/src/get_span.rs
@@ -147,7 +147,8 @@ impl Type {
                 .0
                 .get_span()
                 .merge(&return_type.get_span()),
-            Self::Record(braces) => braces.get_span(),
+            Self::RecordClosed(braces) => braces.get_span(),
+            Self::RecordOpen(braces) => braces.get_span(),
         }
     }
 }

--- a/crates/ditto-cst/src/get_span.rs
+++ b/crates/ditto-cst/src/get_span.rs
@@ -120,6 +120,7 @@ impl Expression {
             Self::False(false_keyword) => false_keyword.0.get_span(),
             Self::Unit(unit_keyword) => unit_keyword.0.get_span(),
             Self::BinOp { lhs, rhs, .. } => lhs.get_span().merge(&rhs.get_span()),
+            Self::RecordAccess { target, label, .. } => target.get_span().merge(&label.get_span()),
         }
     }
 }

--- a/crates/ditto-cst/src/parser/expression.rs
+++ b/crates/ditto-cst/src/parser/expression.rs
@@ -1,8 +1,8 @@
 use super::{parse_rule, Result, Rule};
 use crate::{
-    BinOp, BracesList, BracketsList, CloseBrace, Colon, DoKeyword, Effect, ElseKeyword, Equals,
-    Expression, FalseKeyword, FunctionParameter, IfKeyword, LeftArrow, MatchArm, MatchKeyword,
-    Name, OpenBrace, Parens, ParensList, ParensList1, Pattern, Pipe, QualifiedName,
+    BinOp, BracesList, BracketsList, CloseBrace, Colon, DoKeyword, Dot, Effect, ElseKeyword,
+    Equals, Expression, FalseKeyword, FunctionParameter, IfKeyword, LeftArrow, MatchArm,
+    MatchKeyword, Name, OpenBrace, Parens, ParensList, ParensList1, Pattern, Pipe, QualifiedName,
     QualifiedProperName, RecordField, ReturnKeyword, RightArrow, RightPizzaOperator, Semicolon,
     StringToken, ThenKeyword, TrueKeyword, Type, TypeAnnotation, UnitKeyword, UnusedName,
     WithKeyword,
@@ -193,6 +193,48 @@ impl Expression {
                 });
                 Self::Record(fields)
             }
+            Rule::expression_record_access => {
+                let mut inner = pair.into_inner();
+                let target = Self::from_pair(inner.next().unwrap());
+
+                let mut accessor = inner.next().unwrap().into_inner();
+                let dot = Dot::from_pair(accessor.next().unwrap());
+                let label = Name::from_pair(accessor.next().unwrap());
+                let mut expression = Self::RecordAccess {
+                    target: Box::new(target),
+                    dot,
+                    label,
+                };
+                if let Some(pair) = accessor.next() {
+                    let arguments = ParensList::list_from_pair(pair, |expr_pair| {
+                        Box::new(Self::from_pair(expr_pair))
+                    });
+                    expression = Self::Call {
+                        function: Box::new(expression),
+                        arguments,
+                    }
+                }
+                for accessor in inner {
+                    let mut accessor = accessor.into_inner();
+                    let dot = Dot::from_pair(accessor.next().unwrap());
+                    let label = Name::from_pair(accessor.next().unwrap());
+                    expression = Self::RecordAccess {
+                        target: Box::new(expression),
+                        dot,
+                        label,
+                    };
+                    if let Some(pair) = accessor.next() {
+                        let arguments = ParensList::list_from_pair(pair, |expr_pair| {
+                            Box::new(Self::from_pair(expr_pair))
+                        });
+                        expression = Self::Call {
+                            function: Box::new(expression),
+                            arguments,
+                        }
+                    }
+                }
+                expression
+            }
             other => unreachable!("{:#?} {:#?}", other, pair.into_inner()),
         }
     }
@@ -310,7 +352,9 @@ impl TypeAnnotation {
 #[cfg(test)]
 mod tests {
     use super::test_macros::*;
-    use crate::{BinOp, BracesList, Brackets, CommaSep1, Expression, Parens, StringToken};
+    use crate::{
+        BinOp, BracesList, Brackets, CommaSep1, Expression, Parens, Qualified, StringToken,
+    };
 
     #[test]
     fn it_parses_constructors() {
@@ -752,6 +796,84 @@ mod tests {
         assert_parses!(
             "{ foo = 2, bar = true, }",
             Expression::Record(BracesList { value: Some(_), .. })
+        );
+    }
+
+    #[test]
+    fn it_parses_record_access() {
+        assert_parses!("foo.bar", Expression::RecordAccess { .. });
+        assert_parses!(
+            "Foo.bar.baz",
+            Expression::RecordAccess {
+                target: box Expression::Variable(Qualified {
+                    module_name: Some(_),
+                    ..
+                }),
+                ..
+            }
+        );
+        assert_parses!(
+            "foo.bar.baz",
+            Expression::RecordAccess {
+                target: box Expression::RecordAccess {
+                    target: box Expression::Variable { .. },
+                    ..
+                },
+                ..
+            }
+        );
+        assert_parses!(
+            "foo().bar",
+            Expression::RecordAccess {
+                target: box Expression::Call { .. },
+                ..
+            }
+        );
+        assert_parses!(
+            "foo().bar.baz",
+            Expression::RecordAccess {
+                target: box Expression::RecordAccess {
+                    target: box Expression::Call { .. },
+                    ..
+                },
+                ..
+            }
+        );
+        assert_parses!(
+            "foo.bar.baz()",
+            Expression::Call {
+                function: box Expression::RecordAccess {
+                    target: box Expression::RecordAccess { .. },
+                    ..
+                },
+                ..
+            }
+        );
+        assert_parses!(
+            "foo().bar()",
+            Expression::Call {
+                function: box Expression::RecordAccess {
+                    target: box Expression::Call { .. },
+                    ..
+                },
+                ..
+            }
+        );
+        assert_parses!(
+            "Foo.foo().bar().baz",
+            Expression::RecordAccess {
+                target: box Expression::Call {
+                    function: box Expression::RecordAccess {
+                        target: box Expression::Call {
+                            function: box Expression::Variable(..),
+                            ..
+                        },
+                        ..
+                    },
+                    ..
+                },
+                ..
+            }
         );
     }
 }

--- a/crates/ditto-cst/src/parser/grammar.pest
+++ b/crates/ditto-cst/src/parser/grammar.pest
@@ -135,11 +135,16 @@ expression = _
   | expression_match
   | expression_effect
   | expression_if
+  | expression_3
+  }
+
+expression_3 = _
+  { expression_right_pipe
   | expression_2
   }
 
 expression_2 = _ 
-  { expression_right_pipe
+  { expression_record_access
   | expression_1
   }
 
@@ -155,7 +160,7 @@ expression_0 = _
   | expression_true
   | expression_false
   | expression_unit
-  // It's important that keyword expressions come before variable
+  // It's important that keyword expressions come before `expression_variable`
   | expression_variable 
   | expression_array
   | expression_string
@@ -163,20 +168,26 @@ expression_0 = _
   | expression_integer
   }
 
-// Left-associative (so needs some left recursion hacking)
-expression_right_pipe = { expression_1 ~ right_pizza ~ expression_1 ~ (right_pizza ~ expression_1)* }
+// LEFT-ASSOCIATIVE
+// https://github.com/pest-parser/pest/pull/533
+
+expression_right_pipe = { expression_2 ~ right_pizza ~ expression_2 ~ (right_pizza ~ expression_2)* }
+
+expression_record_access = { expression_1 ~ expression_record_access_accessor+ }
+
+expression_record_access_accessor = { dot ~ name ~ expression_call_arguments? }
+
+expression_call = { expression_0 ~ expression_call_arguments+   }
+
+expression_call_arguments = { open_paren ~ (expression ~ (comma ~ expression)* ~ comma?)?  ~ close_paren }
+
+// END LEFT-ASSOCIATIVE THINGS
 
 expression_parens = { open_paren ~ expression ~ close_paren }
 
 expression_record = { open_brace ~ (expression_record_field ~ (comma ~ expression_record_field)* ~ comma?)?  ~ close_brace }
 
 expression_record_field = { name ~ equals ~ expression }
-
-// No left recursion yet :(
-// https://github.com/pest-parser/pest/pull/533
-expression_call = { expression_0 ~ expression_call_arguments+   }
-
-expression_call_arguments = { open_paren ~ (expression ~ (comma ~ expression)* ~ comma?)?  ~ close_paren }
 
 expression_match = { match_keyword ~ expression ~ with_keyword ~ expression_match_arm+ }
 

--- a/crates/ditto-cst/src/parser/grammar.pest
+++ b/crates/ditto-cst/src/parser/grammar.pest
@@ -102,7 +102,8 @@ type_ = _
 
 type1 = _
   { type_parens
-  | type_record
+  | type_record_closed
+  | type_record_open
   | type_call
   | type_variable  
   | type_constructor
@@ -112,7 +113,9 @@ type_parens = { open_paren ~ type_ ~ close_paren }
 
 type_variable = { name }
 
-type_record = { open_brace ~ (type_record_field ~ (comma ~ type_record_field)* ~ comma?)?  ~ close_brace }
+type_record_closed = { open_brace ~ (type_record_field ~ (comma ~ type_record_field)* ~ comma?)?  ~ close_brace }
+
+type_record_open = { open_brace ~ name ~ pipe ~ type_record_field ~ (comma ~ type_record_field)* ~ comma?  ~ close_brace }
 
 type_record_field = { name ~ colon ~ type_ }
 

--- a/crates/ditto-cst/src/parser/grammar.pest
+++ b/crates/ditto-cst/src/parser/grammar.pest
@@ -150,6 +150,7 @@ expression_1 = _
 
 expression_0 = _ 
   { expression_parens 
+  | expression_record
   | expression_constructor 
   | expression_true
   | expression_false
@@ -166,6 +167,10 @@ expression_0 = _
 expression_right_pipe = { expression_1 ~ right_pizza ~ expression_1 ~ (right_pizza ~ expression_1)* }
 
 expression_parens = { open_paren ~ expression ~ close_paren }
+
+expression_record = { open_brace ~ (expression_record_field ~ (comma ~ expression_record_field)* ~ comma?)?  ~ close_brace }
+
+expression_record_field = { name ~ equals ~ expression }
 
 // No left recursion yet :(
 // https://github.com/pest-parser/pest/pull/533

--- a/crates/ditto-cst/src/parser/grammar.pest
+++ b/crates/ditto-cst/src/parser/grammar.pest
@@ -102,6 +102,7 @@ type_ = _
 
 type1 = _
   { type_parens
+  | type_record
   | type_call
   | type_variable  
   | type_constructor
@@ -110,6 +111,10 @@ type1 = _
 type_parens = { open_paren ~ type_ ~ close_paren }
 
 type_variable = { name }
+
+type_record = { open_brace ~ (type_record_field ~ (comma ~ type_record_field)* ~ comma?)?  ~ close_brace }
+
+type_record_field = { name ~ colon ~ type_ }
 
 type_constructor = { qualified_proper_name }
 

--- a/crates/ditto-cst/src/parser/syntax.rs
+++ b/crates/ditto-cst/src/parser/syntax.rs
@@ -1,7 +1,7 @@
 use super::Rule;
 use crate::{
-    BracketsList, CloseBracket, CloseParen, Comma, CommaSep1, OpenBracket, OpenParen, Parens,
-    ParensList, ParensList1,
+    BracesList, BracketsList, CloseBrace, CloseBracket, CloseParen, Comma, CommaSep1, OpenBrace,
+    OpenBracket, OpenParen, Parens, ParensList, ParensList1,
 };
 use itertools::{EitherOrBoth, Itertools};
 use pest::iterators::Pair;
@@ -94,6 +94,33 @@ impl<T> BracketsList<T> {
                     open_bracket,
                     value: Some(value),
                     close_bracket,
+                }
+            }
+        }
+    }
+}
+
+impl<T> BracesList<T> {
+    pub(super) fn list_from_pair(
+        pair: Pair<Rule>,
+        element_from_pair: impl Fn(Pair<Rule>) -> T,
+    ) -> Self {
+        let mut inner = pair.into_inner();
+        let open_brace = OpenBrace::from_pair(inner.next().unwrap());
+        let mut rest = inner.collect::<Vec<_>>();
+        let close_brace = CloseBrace::from_pair(rest.pop().unwrap());
+        match rest.split_first() {
+            None => Self {
+                open_brace,
+                value: None,
+                close_brace,
+            },
+            Some((head, tail)) => {
+                let value = CommaSep1::from_pairs(head, tail, element_from_pair);
+                Self {
+                    open_brace,
+                    value: Some(value),
+                    close_brace,
                 }
             }
         }

--- a/crates/ditto-cst/src/syntax.rs
+++ b/crates/ditto-cst/src/syntax.rs
@@ -1,4 +1,4 @@
-use crate::{CloseBracket, CloseParen, Comma, OpenBracket, OpenParen};
+use crate::{CloseBrace, CloseBracket, CloseParen, Comma, OpenBrace, OpenBracket, OpenParen};
 use std::iter;
 
 /// A value surrounded by parentheses.
@@ -21,6 +21,17 @@ pub struct Brackets<T> {
     pub value: T,
     /// `]`
     pub close_bracket: CloseBracket,
+}
+
+/// A value surrounded by braces.
+#[derive(Debug, Clone)]
+pub struct Braces<T> {
+    /// `{`
+    pub open_brace: OpenBrace,
+    /// The contents of the braces.
+    pub value: T,
+    /// `}`
+    pub close_brace: CloseBrace,
 }
 
 /// A list of items surrounded by parentheses
@@ -57,6 +68,17 @@ pub type ParensList1<T> = Parens<CommaSep1<T>>;
 /// [foo, bar, baz,]
 /// ```
 pub type BracketsList<T> = Brackets<Option<CommaSep1<T>>>;
+
+/// A list of items surrounded by braces.
+///
+/// Used to represent the following:
+///
+/// ```ditto
+/// {}
+/// { foo = 2 }
+/// {foo = bar, baz = bar, }
+/// ```
+pub type BracesList<T> = Braces<Option<CommaSep1<T>>>;
 
 /// A comma-separated, non-empty list of items.
 ///

--- a/crates/ditto-cst/src/type.rs
+++ b/crates/ditto-cst/src/type.rs
@@ -1,5 +1,6 @@
 use crate::{
-    BracesList, Colon, Name, Parens, ParensList, ParensList1, QualifiedProperName, RightArrow,
+    Braces, BracesList, Colon, CommaSep1, Name, Parens, ParensList, ParensList1, Pipe,
+    QualifiedProperName, RightArrow,
 };
 
 /// Syntax representation of expression types.
@@ -43,7 +44,9 @@ pub enum Type {
     /// A named type variable.
     Variable(Name),
     /// `{ foo : Int, bar: Bool }`
-    Record(BracesList<RecordTypeField>),
+    RecordClosed(BracesList<RecordTypeField>),
+    /// `{ r | foo : Int, bar: Bool }`
+    RecordOpen(Braces<(Name, Pipe, CommaSep1<RecordTypeField>)>),
 }
 
 /// A labelled type within a record.

--- a/crates/ditto-cst/src/type.rs
+++ b/crates/ditto-cst/src/type.rs
@@ -1,4 +1,6 @@
-use crate::{Name, Parens, ParensList, ParensList1, QualifiedProperName, RightArrow};
+use crate::{
+    BracesList, Colon, Name, Parens, ParensList, ParensList1, QualifiedProperName, RightArrow,
+};
 
 /// Syntax representation of expression types.
 #[derive(Debug, Clone)]
@@ -40,6 +42,19 @@ pub enum Type {
     Constructor(QualifiedProperName),
     /// A named type variable.
     Variable(Name),
+    /// `{ foo : Int, bar: Bool }`
+    Record(BracesList<RecordTypeField>),
+}
+
+/// A labelled type within a record.
+#[derive(Debug, Clone)]
+pub struct RecordTypeField {
+    /// The field label.
+    pub label: Name,
+    /// `:`
+    pub colon: Colon,
+    /// The type to be associated with the `label`.
+    pub value: Box<Type>,
 }
 
 /// Valid targets for a type call.

--- a/crates/ditto-fmt/src/type.rs
+++ b/crates/ditto-fmt/src/type.rs
@@ -2,14 +2,14 @@ use super::{
     has_comments::HasComments,
     helpers::{group, space},
     name::{gen_name, gen_qualified_proper_name},
-    syntax::{gen_parens, gen_parens_list, gen_parens_list1},
-    token::gen_right_arrow,
+    syntax::{gen_braces_list, gen_comma_sep1, gen_parens, gen_parens_list, gen_parens_list1},
+    token::{gen_close_brace, gen_colon, gen_open_brace, gen_pipe, gen_right_arrow},
 };
-use ditto_cst::{Type, TypeCallFunction};
-use dprint_core::formatting::{ir_helpers, PrintItems};
+use ditto_cst::{Braces, RecordTypeField, Type, TypeCallFunction};
+use dprint_core::formatting::{conditions, ir_helpers, PrintItems, Signal};
 
 pub fn gen_type(t: Type) -> PrintItems {
-    match t {
+    return match t {
         // TODO remove redundant parens?
         Type::Parens(parens) => gen_parens(parens, |box t| gen_type(t)),
         Type::Variable(name) => gen_name(name),
@@ -54,6 +54,66 @@ pub fn gen_type(t: Type) -> PrintItems {
             ));
             items
         }
+        Type::RecordClosed(braces) => gen_braces_list(braces, gen_record_type_field),
+        Type::RecordOpen(Braces {
+            open_brace,
+            value: (var, pipe, fields),
+            close_brace,
+        }) => {
+            let mut items = PrintItems::new();
+            let force_use_new_lines =
+                open_brace.0.has_comments() || var.has_comments() || pipe.0.has_comments();
+            let gen_separated_values_result =
+                gen_comma_sep1(fields, gen_record_type_field, force_use_new_lines);
+
+            let fields = gen_separated_values_result.items.into_rc_path();
+            items.push_condition(conditions::if_true_or(
+                "multiLineOpenRecordType",
+                gen_separated_values_result
+                    .is_multi_line_condition_ref
+                    .create_resolver(),
+                {
+                    let mut items = gen_open_brace(open_brace.clone());
+                    items.push_signal(Signal::NewLine);
+                    items.extend(ir_helpers::with_indent({
+                        let mut items = gen_name(var.clone());
+                        items.extend(space());
+                        items.extend(gen_pipe(pipe.clone()));
+                        items.extend(fields.into());
+                        items
+                    }));
+                    items.extend(gen_close_brace(close_brace.clone()));
+                    items
+                },
+                {
+                    let mut items = gen_open_brace(open_brace);
+                    items.push_signal(Signal::SpaceOrNewLine);
+                    items.extend(gen_name(var));
+                    items.extend(space());
+                    items.extend(gen_pipe(pipe));
+                    items.extend(space());
+                    items.extend(fields.into());
+                    items.extend(space());
+                    items.extend(gen_close_brace(close_brace));
+                    items
+                },
+            ));
+            items
+        }
+    };
+
+    fn gen_record_type_field(field: RecordTypeField) -> PrintItems {
+        let RecordTypeField {
+            label,
+            colon,
+            box value,
+        } = field;
+        let mut items = PrintItems::new();
+        items.extend(gen_name(label));
+        items.extend(gen_colon(colon));
+        let force_use_new_lines = value.has_leading_comments();
+        items.extend(group(gen_type(value), force_use_new_lines));
+        items
     }
 }
 
@@ -111,5 +171,23 @@ mod tests {
             "() -> (a, b) ->\n\t(c) -> d",
             15
         );
+    }
+
+    #[test]
+    fn it_formats_closed_records() {
+        assert_fmt!("{}");
+        assert_fmt!("{\n\t-- comment\n}");
+        assert_fmt!("{  -- comment\n}");
+        assert_fmt!("{ foo: Foo }");
+        assert_fmt!("{ foo: Foo, bar: Bar, baz: {} }");
+        assert_fmt!("{\n\t-- comment\n\tfoo: Foo,\n\tbar: Bar,\n\tbaz: {},\n}");
+        assert_fmt!("{\n\t-- comment\n\tfoo:\n\t\t-- comment\n\t\tFoo,\n}");
+    }
+
+    #[test]
+    fn it_formats_open_records() {
+        assert_fmt!("{ r | foo: Int }");
+        assert_fmt!("{\n\tr |\n\t\t-- comment\n\t\tfoo: Int,\n}");
+        assert_fmt!("{\n\t-- comment\n\tr |\n\t\tfoo: Int,\n}");
     }
 }

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,9 +1,11 @@
-const path = require("node:path");
+import path from "node:path";
+
 function prepareFilenames(filenames) {
   const cwd = process.cwd();
   return filenames.map(file => path.relative(cwd, file)).join(" ");
 }
-module.exports = {
+
+export default {
   "*.rs": filenames => [
     `cargo fmt -- ${prepareFilenames(filenames)}`,
     // If this fails, try running

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "type": "module",
   "dependencies": {
     "prettier": "2.6.0"
   },


### PR DESCRIPTION
Closes #11 and #53.

It made sense to implement both of these features at once as the implementation of one kinda informed the other. And it made testing easier.

[Extensible records with scoped labels](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/scopedlabels.pdf) is essential reading. 👌 