### PR TITLE
Attempt to fix slow pest parser 😞 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ target
 
 # NPM
 node_modules
+
+# Local benchmarks
+control.bench
+latest.bench

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,9 +1001,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "lock_api"

--- a/crates/ditto-cst/benches/expressions.rs
+++ b/crates/ditto-cst/benches/expressions.rs
@@ -1,0 +1,39 @@
+/*
+cargo bench -p ditto-cst > control
+cargo bench -p ditto-cst > latest && cargo benchcmp --threshold 5 control latest
+*/
+#![feature(test)]
+
+extern crate test;
+
+use test::Bencher;
+
+#[bench]
+fn bench_qualified_variable(b: &mut Bencher) {
+    b.iter(|| ditto_cst::Expression::parse("Foo.bar"));
+}
+
+#[bench]
+fn bench_long_pipe(b: &mut Bencher) {
+    b.iter(|| ditto_cst::Expression::parse("x |> x |> x |> x |> x |> x"));
+}
+
+#[bench]
+fn bench_very_curried_function(b: &mut Bencher) {
+    b.iter(|| ditto_cst::Expression::parse("() -> () -> () -> () -> () -> () -> unit"));
+}
+
+#[bench]
+fn bench_empty_array(b: &mut Bencher) {
+    b.iter(|| ditto_cst::Expression::parse("[]"));
+}
+
+#[bench]
+fn bench_nested_array(b: &mut Bencher) {
+    b.iter(|| ditto_cst::Expression::parse("[[[x]]]"));
+}
+
+#[bench]
+fn bench_empty_record(b: &mut Bencher) {
+    b.iter(|| ditto_cst::Expression::parse("{}"));
+}

--- a/crates/ditto-cst/src/parser/grammar.pest
+++ b/crates/ditto-cst/src/parser/grammar.pest
@@ -113,9 +113,9 @@ type_parens = { open_paren ~ type_ ~ close_paren }
 
 type_variable = { name }
 
-type_record_closed = { open_brace ~ (type_record_field ~ (comma ~ type_record_field)* ~ comma?)?  ~ close_brace }
+type_record_closed = { open_brace ~ close_brace | open_brace ~ type_record_field ~ (comma ~ type_record_field)* ~ comma? ~ close_brace }
 
-type_record_open = { open_brace ~ name ~ pipe ~ type_record_field ~ (comma ~ type_record_field)* ~ comma?  ~ close_brace }
+type_record_open = { open_brace ~ name ~ pipe ~ type_record_field ~ (comma ~ type_record_field)* ~ comma? ~ close_brace }
 
 type_record_field = { name ~ colon ~ type_ }
 
@@ -129,7 +129,7 @@ type_call_arguments = { open_paren ~ type_ ~ (comma ~ type_)* ~ comma? ~ close_p
 
 type_function = { type_function_parameters ~ right_arrow ~ type_ }
 
-type_function_parameters = { open_paren ~ (type_ ~ (comma ~ type_)* ~ comma?)?  ~ close_paren }
+type_function_parameters = { open_paren ~ close_paren | open_paren ~ type_ ~ (comma ~ type_)* ~ comma? ~ close_paren }
 
 type_annotation = { colon ~ type_ }
 
@@ -164,36 +164,41 @@ expression_1 = _
 expression_0 = _ 
   { expression_parens 
   | expression_record
+  | expression_array
+
+  // Literals
+  | expression_string
+  | expression_float
+  | expression_integer
+
   | expression_constructor 
+
+  // Keywords
   | expression_true
   | expression_false
   | expression_unit
   // It's important that keyword expressions come before `expression_variable`
   | expression_variable 
-  | expression_array
-  | expression_string
-  | expression_float
-  | expression_integer
   }
 
 // LEFT-ASSOCIATIVE
 // https://github.com/pest-parser/pest/pull/533
 
-expression_right_pipe = { expression_2 ~ right_pizza ~ expression_2 ~ (right_pizza ~ expression_2)* }
+expression_right_pipe = { expression_2 ~ (right_pizza ~ expression_2)+ }
 
 expression_record_access = { expression_1 ~ expression_record_access_accessor+ }
 
 expression_record_access_accessor = { dot ~ name ~ expression_call_arguments? }
 
-expression_call = { expression_0 ~ expression_call_arguments+   }
+expression_call = { expression_0 ~ expression_call_arguments+ }
 
-expression_call_arguments = { open_paren ~ (expression ~ (comma ~ expression)* ~ comma?)?  ~ close_paren }
+expression_call_arguments = { open_paren ~ close_paren | open_paren ~ expression ~ (comma ~ expression)* ~ comma? ~ close_paren }
 
 // END LEFT-ASSOCIATIVE THINGS
 
 expression_parens = { open_paren ~ expression ~ close_paren }
 
-expression_record = { open_brace ~ (expression_record_field ~ (comma ~ expression_record_field)* ~ comma?)?  ~ close_brace }
+expression_record = { open_brace ~ close_brace | open_brace ~ expression_record_field ~ (comma ~ expression_record_field)* ~ comma? ~ close_brace }
 
 expression_record_field = { name ~ equals ~ expression }
 
@@ -219,7 +224,7 @@ expression_constructor = { qualified_proper_name }
 
 expression_function = { expression_function_parameters ~ return_type_annotation? ~ right_arrow ~ expression }
 
-expression_function_parameters = { open_paren ~ (expression_function_parameter ~ (comma ~ expression_function_parameter)* ~ comma?)?  ~ close_paren }
+expression_function_parameters = { open_paren ~ close_paren | open_paren ~ expression_function_parameter ~ (comma ~ expression_function_parameter)* ~ comma? ~ close_paren }
 
 expression_function_parameter = { (name | unused_name) ~ type_annotation? }
 
@@ -227,7 +232,7 @@ expression_if = { if_keyword ~ expression ~ then_keyword ~ expression ~ else_key
 
 expression_variable = { qualified_name }
 
-expression_array = { open_bracket ~ (expression ~ (comma ~ expression)* ~ comma?)?  ~ close_bracket }
+expression_array = { open_bracket ~ close_bracket | open_bracket ~ expression ~ (comma ~ expression)* ~ comma? ~ close_bracket }
 
 expression_string = { string_literal }
 
@@ -251,7 +256,7 @@ pattern_constructor = { pattern_constructor_proper_name ~ pattern_constructor_ar
 
 pattern_constructor_proper_name = { qualified_proper_name }
 
-pattern_constructor_arguments = { open_paren ~ (pattern ~ (comma ~ pattern)* ~ comma?)?  ~ close_paren }
+pattern_constructor_arguments = { open_paren ~ pattern ~ (comma ~ pattern)* ~ comma? ~ close_paren }
 
 pattern_variable = { name }
 
@@ -269,85 +274,85 @@ qualifier = { proper_name ~ dot }
 // -----------------------------------------------------------------------------
 // Token rules
 
-name = ${ (WHITESPACE | LINE_COMMENT)* ~ NAME ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+name = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ NAME ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-unused_name = ${ (WHITESPACE | LINE_COMMENT)* ~ UNUSED_NAME ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+unused_name = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ UNUSED_NAME ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-proper_name = ${ (WHITESPACE | LINE_COMMENT)* ~ PROPER_NAME ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+proper_name = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ PROPER_NAME ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-package_name = ${ (WHITESPACE | LINE_COMMENT)* ~ PACKAGE_NAME ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+package_name = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ PACKAGE_NAME ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-integer_literal = ${ (WHITESPACE | LINE_COMMENT)* ~ INTEGER ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+integer_literal = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ INTEGER ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-float_literal = ${ (WHITESPACE | LINE_COMMENT)* ~ FLOAT ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+float_literal = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ FLOAT ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-string_literal = ${ (WHITESPACE | LINE_COMMENT)* ~ STRING ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+string_literal = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ STRING ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-true_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ TRUE_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+true_keyword = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ TRUE_KEYWORD ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-false_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ FALSE_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+false_keyword = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ FALSE_KEYWORD ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-unit_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ UNIT_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+unit_keyword = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ UNIT_KEYWORD ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-if_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ IF_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+if_keyword = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ IF_KEYWORD ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-then_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ THEN_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+then_keyword = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ THEN_KEYWORD ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-else_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ ELSE_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+else_keyword = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ ELSE_KEYWORD ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-module_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ MODULE_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+module_keyword = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ MODULE_KEYWORD ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-exports_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ EXPORTS_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+exports_keyword = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ EXPORTS_KEYWORD ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-import_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ IMPORT_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+import_keyword = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ IMPORT_KEYWORD ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-as_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ AS_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+as_keyword = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ AS_KEYWORD ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-type_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ TYPE_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+type_keyword = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ TYPE_KEYWORD ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-foreign_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ FOREIGN_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+foreign_keyword = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ FOREIGN_KEYWORD ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-match_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ MATCH_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+match_keyword = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ MATCH_KEYWORD ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-do_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ DO_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+do_keyword = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ DO_KEYWORD ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-return_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ RETURN_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+return_keyword = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ RETURN_KEYWORD ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-let_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ LET_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+let_keyword = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ LET_KEYWORD ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-with_keyword = ${ (WHITESPACE | LINE_COMMENT)* ~ WITH_KEYWORD ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+with_keyword = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ WITH_KEYWORD ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-dot = ${ (WHITESPACE | LINE_COMMENT)* ~ DOT ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+dot = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ DOT ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-pipe = ${ (WHITESPACE | LINE_COMMENT)* ~ PIPE ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+pipe = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ PIPE ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-right_pizza = ${ (WHITESPACE | LINE_COMMENT)* ~ RIGHT_PIZZA ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+right_pizza = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ RIGHT_PIZZA ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-double_dot = ${ (WHITESPACE | LINE_COMMENT)* ~ DOUBLE_DOT ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+double_dot = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ DOUBLE_DOT ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-comma = ${ (WHITESPACE | LINE_COMMENT)* ~ COMMA ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+comma = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ COMMA ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-colon = ${ (WHITESPACE | LINE_COMMENT)* ~ COLON ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+colon = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ COLON ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-semicolon = ${ (WHITESPACE | LINE_COMMENT)* ~ SEMICOLON ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+semicolon = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ SEMICOLON ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-equals = ${ (WHITESPACE | LINE_COMMENT)* ~ EQUALS ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+equals = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ EQUALS ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-right_arrow = ${ (WHITESPACE | LINE_COMMENT)* ~ RIGHT_ARROW ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+right_arrow = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ RIGHT_ARROW ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-left_arrow = ${ (WHITESPACE | LINE_COMMENT)* ~ LEFT_ARROW ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+left_arrow = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ LEFT_ARROW ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-open_paren = ${ (WHITESPACE | LINE_COMMENT)* ~ OPEN_PAREN ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+open_paren = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ OPEN_PAREN ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-close_paren = ${ (WHITESPACE | LINE_COMMENT)* ~ CLOSE_PAREN ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+close_paren = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ CLOSE_PAREN ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-open_bracket = ${ (WHITESPACE | LINE_COMMENT)* ~ OPEN_BRACKET ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+open_bracket = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ OPEN_BRACKET ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-close_bracket = ${ (WHITESPACE | LINE_COMMENT)* ~ CLOSE_BRACKET ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+close_bracket = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ CLOSE_BRACKET ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-open_brace = ${ (WHITESPACE | LINE_COMMENT)* ~ OPEN_BRACE ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+open_brace = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ OPEN_BRACE ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
-close_brace = ${ (WHITESPACE | LINE_COMMENT)* ~ CLOSE_BRACE ~ HORIZONTAL_WHITESPACE? ~ LINE_COMMENT? }
+close_brace = ${ (LINE_COMMENT ~ WHITESPACE*)* ~ CLOSE_BRACE ~ HORIZONTAL_WHITESPACE* ~ LINE_COMMENT? }
 
 // -----------------------------------------------------------------------------
 // Atom rules (uppercase by convention)
@@ -435,13 +440,17 @@ CLOSE_BRACE = { "}" }
 
 DOUBLE_QUOTE = { "\"" }
 
+// -----------------------------------------------------------------------------
+// "Skipped" rules
+
 // NOTE: we don't call this `COMMENT` because we don't want pest to automatically
 // consume (and drop!) comments
-LINE_COMMENT = @{ "--" ~ (!NEWLINE ~ ANY)* } // TODO unicode?
+LINE_COMMENT = @{ "--" ~ (!NEWLINE ~ ANY)* }
 
-// -----------------------------------------------------------------------------
-// Special rules names (see https://docs.rs/pest_derive/2.1.0/pest_derive/#whitespace-and-comment)
+WHITESPACE = _{ SPACE | TAB | NEWLINE }
 
-WHITESPACE = _{ (" " | "\t" | NEWLINE)+ } // TODO unicode?
+HORIZONTAL_WHITESPACE = _{ SPACE | TAB }
 
-HORIZONTAL_WHITESPACE = _{ (" " | "\t")+ } // TODO unicode?
+SPACE = _{ " " } // TODO unicode?
+
+TAB = _{ "\t" } // TODO unicode?

--- a/shell.nix
+++ b/shell.nix
@@ -21,6 +21,19 @@ let
   };
   inherit (fenixPackages) rust-analyzer;
 
+  cargo-benchcmp = pkgs.rustPlatform.buildRustPackage rec {
+    pname = "cargo-benchcmp";
+    version = "0.4.3";
+    src = pkgs.fetchFromGitHub {
+      owner = "BurntSushi";
+      repo = pname;
+      rev = version;
+      sha256 = "sha256-nD/qFqq1DOmNZGW4g9Xjpwob/T7d6egFdFMNFG+N+f0=";
+    };
+    cargoSha256 = "sha256-frNoGzeOPo/gUksaquiFdRhUd486BABcoznW29FzIK8=";
+    doCheck = false;
+  };
+
   # Should match .nvmrc
   # Also see: https://nixos.wiki/wiki/Node.js#Example_nix_shell_for_Node.js_development
   # (but note building Node from source takes aaages)
@@ -34,6 +47,7 @@ in pkgs.mkShell {
     pkgs.cargo-audit
     pkgs.cargo-outdated
     pkgs.cargo-tarpaulin
+    cargo-benchcmp
     nodejs
     pkgs.ninja
     pkgs.openssl


### PR DESCRIPTION
Nested arrays (`[[[x]]]`) and records (`{ a = { b = { c = {} } } }`) are taking ages to parse (as I discovered [here](https://github.com/ditto-lang/ditto/pull/54/files#diff-2e12ac3b8b2ed016987c0887d58af21bab1b8bb9586d5681194eb6a218c34f33R7-R8) in #54)

This PR includes some failed attempts to fix that.

Next steps: probably switch to [lalrpop](https://github.com/lalrpop/lalrpop) or [pom](https://github.com/J-F-Liu/pom) 👀 