### PR TITLE
Make the CST serializable

### DIFF
--- a/crates/ditto-cst/src/expression.rs
+++ b/crates/ditto-cst/src/expression.rs
@@ -5,9 +5,10 @@ use crate::{
     RightPizzaOperator, Semicolon, StringToken, ThenKeyword, TrueKeyword, Type, UnitKeyword,
     UnusedName, WithKeyword,
 };
+use serde::{Deserialize, Serialize};
 
 /// A value expression.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Expression {
     /// An expression wrapped in parentheses.
     Parens(Parens<Box<Self>>),
@@ -154,7 +155,7 @@ pub enum Expression {
 }
 
 /// A labelled expression within a record.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecordField {
     /// The field label.
     pub label: Name,
@@ -165,7 +166,7 @@ pub struct RecordField {
 }
 
 /// A function expression parameter.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum FunctionParameter {
     /// A name to be bound in the body of the function.
     Name(Name),
@@ -174,14 +175,14 @@ pub enum FunctionParameter {
 }
 
 /// A binary operator.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum BinOp {
     /// `|>`
     RightPizza(RightPizzaOperator),
 }
 
 /// A chain of Effect statements.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Effect {
     /// `do { return expression }`
     Return {
@@ -217,7 +218,7 @@ pub enum Effect {
 /// ```ditto
 /// | Pattern -> expression
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MatchArm {
     /// `|`
     pub pipe: Pipe,
@@ -230,7 +231,7 @@ pub struct MatchArm {
 }
 
 /// A pattern to be matched.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum Pattern {
     /// A constructor pattern without arguments.
@@ -258,5 +259,5 @@ pub enum Pattern {
 }
 
 /// `: String`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TypeAnnotation(pub Colon, pub Type);

--- a/crates/ditto-cst/src/module.rs
+++ b/crates/ditto-cst/src/module.rs
@@ -3,10 +3,11 @@ use crate::{
     ImportKeyword, ModuleKeyword, ModuleName, Name, PackageName, Parens, ParensList1, Pipe,
     ProperName, Semicolon, Type, TypeAnnotation, TypeKeyword,
 };
+use serde::{Deserialize, Serialize};
 use std::iter;
 
 /// A ditto (source) module.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Module {
     /// The module header declares the module's name and exports.
     pub header: Header,
@@ -19,7 +20,7 @@ pub struct Module {
 }
 
 /// `module Some.Module exports (..);`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Header {
     /// `module`
     pub module_keyword: ModuleKeyword,
@@ -37,7 +38,7 @@ pub struct Header {
 pub type Everything = Parens<DoubleDot>;
 
 /// A list of things to be exported.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Exports {
     /// `(..)`
     Everything(Everything),
@@ -46,7 +47,7 @@ pub enum Exports {
 }
 
 /// An item in an [Exports] list.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Export {
     /// `foo`
     Value(Name),
@@ -55,7 +56,7 @@ pub enum Export {
 }
 
 /// `import (some_package) Some.Module as Alias (..);`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImportLine {
     /// `import`
     pub import_keyword: ImportKeyword,
@@ -74,11 +75,11 @@ pub struct ImportLine {
 /// A list of things to be imported.
 ///
 /// `(Foo, Bar(..), baz)`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImportList(pub ParensList1<Import>);
 
 /// An item in an [Import] list.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Import {
     /// `foo`
     Value(Name),
@@ -87,7 +88,7 @@ pub enum Import {
 }
 
 /// Declarations are the body of a module.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Declaration {
     /// Binding an expression to a top-level name.
     Value(Box<ValueDeclaration>),
@@ -102,7 +103,7 @@ pub enum Declaration {
 /// ```ditto
 /// name : type = expression;
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ValueDeclaration {
     /// Name of this value.
     pub name: Name,
@@ -118,7 +119,7 @@ pub struct ValueDeclaration {
 
 /// Introducing a new type.
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TypeDeclaration {
     /// ```ditto
     /// type Maybe(a) =
@@ -208,7 +209,7 @@ impl TypeDeclaration {
 }
 
 /// A type constructor, like `Just` or `Nothing`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Constructor<P = Pipe> {
     /// `|`
     pub pipe: P,
@@ -223,7 +224,7 @@ pub struct Constructor<P = Pipe> {
 /// ```ditto
 /// foreign foo : Int;
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ForeignValueDeclaration {
     /// `foreign`
     pub foreign_keyword: ForeignKeyword,

--- a/crates/ditto-cst/src/name.rs
+++ b/crates/ditto-cst/src/name.rs
@@ -1,23 +1,24 @@
 use crate::{Dot, StringToken};
+use serde::{Deserialize, Serialize};
 
 /// A "proper name" begins with an upper case letter.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProperName(pub StringToken);
 
 /// A "name" begins with a lower case letter.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Name(pub StringToken);
 
 /// An "unused name" begins with a single underscore.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UnusedName(pub StringToken);
 
 /// A package name consists of lower case letters, numbers and hyphens. It must start with a letter.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PackageName(pub StringToken);
 
 /// Something is "qualified" if it can have an initial module name.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Qualified<Value> {
     /// The optional module name qualification.
     pub module_name: Option<(ProperName, Dot)>,
@@ -33,7 +34,7 @@ pub type QualifiedProperName = Qualified<ProperName>;
 pub type QualifiedName = Qualified<Name>;
 
 /// A [ModuleName] is a non-empty collection of [ProperName]s, joined by dots.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModuleName {
     /// Any leading [ProperName]s and the dots that follow them.
     pub init: Vec<(ProperName, Dot)>,

--- a/crates/ditto-cst/src/syntax.rs
+++ b/crates/ditto-cst/src/syntax.rs
@@ -1,8 +1,9 @@
 use crate::{CloseBrace, CloseBracket, CloseParen, Comma, OpenBrace, OpenBracket, OpenParen};
+use serde::{Deserialize, Serialize};
 use std::iter;
 
 /// A value surrounded by parentheses.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Parens<T> {
     /// `(`
     pub open_paren: OpenParen,
@@ -13,7 +14,7 @@ pub struct Parens<T> {
 }
 
 /// A value surrounded by brackets.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Brackets<T> {
     /// `[`
     pub open_bracket: OpenBracket,
@@ -24,7 +25,7 @@ pub struct Brackets<T> {
 }
 
 /// A value surrounded by braces.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Braces<T> {
     /// `{`
     pub open_brace: OpenBrace,
@@ -89,7 +90,7 @@ pub type BracesList<T> = Braces<Option<CommaSep1<T>>>;
 /// foo, bar
 /// foo, bar, baz,
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommaSep1<T> {
     /// The first item.
     pub head: T,

--- a/crates/ditto-cst/src/token.rs
+++ b/crates/ditto-cst/src/token.rs
@@ -30,7 +30,7 @@ impl Span {
 /// -- leading comment
 /// token -- trailing comment
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Token<Value> {
     /// The source location of this token.
     pub span: Span,
@@ -67,7 +67,7 @@ impl<Value> Token<Value> {
 }
 
 /// A string token prefixed with `"--"`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Comment(pub String);
 
 /// A [String] syntax node.
@@ -81,141 +81,141 @@ pub type StringToken = Token<String>;
 pub type EmptyToken = Token<()>;
 
 /// `.`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Dot(pub EmptyToken);
 
 /// `..`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DoubleDot(pub EmptyToken);
 
 /// `,`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Comma(pub EmptyToken);
 
 /// `:`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Colon(pub EmptyToken);
 
 /// `;`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Semicolon(pub EmptyToken);
 
 /// `=`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Equals(pub EmptyToken);
 
 /// `(`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OpenParen(pub EmptyToken);
 
 /// `)`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CloseParen(pub EmptyToken);
 
 /// `[`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OpenBracket(pub EmptyToken);
 
 /// `]`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CloseBracket(pub EmptyToken);
 
 /// `{`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OpenBrace(pub EmptyToken);
 
 /// `}`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CloseBrace(pub EmptyToken);
 
 /// `<-`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LeftArrow(pub EmptyToken);
 
 /// `->`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RightArrow(pub EmptyToken);
 
 /// `|`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Pipe(pub EmptyToken);
 
 /// `module`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModuleKeyword(pub EmptyToken);
 
 /// `exports`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExportsKeyword(pub EmptyToken);
 
 /// `import`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImportKeyword(pub EmptyToken);
 
 /// `as`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AsKeyword(pub EmptyToken);
 
 /// `true`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TrueKeyword(pub EmptyToken);
 
 /// `false`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FalseKeyword(pub EmptyToken);
 
 /// `unit`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UnitKeyword(pub EmptyToken);
 
 /// `if`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IfKeyword(pub EmptyToken);
 
 /// `then`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ThenKeyword(pub EmptyToken);
 
 /// `else`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ElseKeyword(pub EmptyToken);
 
 /// `type`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TypeKeyword(pub EmptyToken);
 
 /// `foreign`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ForeignKeyword(pub EmptyToken);
 
 /// `match`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MatchKeyword(pub EmptyToken);
 
 /// `with`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WithKeyword(pub EmptyToken);
 
 /// `let`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LetKeyword(pub EmptyToken);
 
 /// `do`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DoKeyword(pub EmptyToken);
 
 /// `return`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReturnKeyword(pub EmptyToken);
 
 /// `fn`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FnKeyword(pub EmptyToken);
 
 /// `end`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EndKeyword(pub EmptyToken);
 
 /// `|>`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RightPizzaOperator(pub EmptyToken);

--- a/crates/ditto-cst/src/type.rs
+++ b/crates/ditto-cst/src/type.rs
@@ -2,9 +2,10 @@ use crate::{
     Braces, BracesList, Colon, CommaSep1, Name, Parens, ParensList, ParensList1, Pipe,
     QualifiedProperName, RightArrow,
 };
+use serde::{Deserialize, Serialize};
 
 /// Syntax representation of expression types.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Type {
     /// A type wrapped in parentheses.
     Parens(Parens<Box<Self>>),
@@ -50,7 +51,7 @@ pub enum Type {
 }
 
 /// A labelled type within a record.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecordTypeField {
     /// The field label.
     pub label: Name,
@@ -61,7 +62,7 @@ pub struct RecordTypeField {
 }
 
 /// Valid targets for a type call.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TypeCallFunction {
     /// A type constructor.
     ///


### PR DESCRIPTION
I thought this might enable some useful optimizations, on the assumption that parsing is expensive.

However a quick test showed that deserializing a serialized CST is _considerably_ slower than parsing.

Specifically, I grabbed the [gibberish](https://github.com/ditto-lang/ditto/pull/56#issuecomment-1145008957) CST I generated previously and ran the following:

```rust
// crates/ditto-cst/examples/parsing_vs_deser.rs
use ditto_cst::Module;
use std::path::Path;

fn main() {
    let module = read_and_parse("gibberish.txt");
    let file = std::fs::File::create("gibberish.json").unwrap();
    serde_json::to_writer(file, &module).unwrap();
    deserialize_json("gibberish.json");
}

fn read_and_parse<P: AsRef<Path>>(path: P) -> Module {
    let start = std::time::SystemTime::now();
    let input = std::fs::read_to_string(path).unwrap();
    let module = Module::parse(&input).unwrap();
    let end = std::time::SystemTime::now();
    println!(
        "reading and parsing took: {:?}",
        end.duration_since(start).unwrap()
    );
    module
}

// Also tried this with CBOR and the result was the same
fn deserialize_json<P: AsRef<Path>>(path: P) {
    let start = std::time::SystemTime::now();
    let file = std::fs::File::open(path).unwrap();
    let reader = std::io::BufReader::new(file);
    let _: Module = serde_json::from_reader(reader).unwrap();
    let end = std::time::SystemTime::now();
    println!(
        "cbor deserialization took: {:?}",
        end.duration_since(start).unwrap()
    )
}
// cargo run -p ditto-cst --release --example parsing_vs_deser
```

`deserialize_json` hung for ages and then crashed due to a recursion limit.  