### PR TITLE
Stop messing around with line endings, just use LF 👨‍⚖️

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/crates/ditto-checker/src/result/mod.rs
+++ b/crates/ditto-checker/src/result/mod.rs
@@ -9,7 +9,7 @@ pub type Result<T> = std::result::Result<T, TypeError>;
 
 #[cfg(test)]
 mod tests {
-    #[snapshot_test::snapshot_lf(
+    #[snapshot_test::snapshot(
         input = "golden-tests/warnings/(.*).ditto",
         output = "golden-tests/warnings/${1}.warnings"
     )]
@@ -40,7 +40,7 @@ mod tests {
             .join("\n")
     }
 
-    #[snapshot_test::snapshot_lf(
+    #[snapshot_test::snapshot(
         input = "golden-tests/type-errors/(.*).ditto",
         output = "golden-tests/type-errors/${1}.error"
     )]

--- a/crates/ditto-codegen-js/src/lib.rs
+++ b/crates/ditto-codegen-js/src/lib.rs
@@ -21,7 +21,7 @@ mod tests {
     use ditto_checker as checker;
     use ditto_cst as cst;
 
-    #[snapshot_test::snapshot_lf(
+    #[snapshot_test::snapshot(
         input = "golden-tests/javascript/(.*).ditto",
         output = "golden-tests/javascript/${1}.js"
     )]

--- a/crates/ditto-codegen-js/src/render.rs
+++ b/crates/ditto-codegen-js/src/render.rs
@@ -8,12 +8,6 @@ pub fn render_module(module: Module) -> String {
     accum
 }
 
-#[cfg(windows)]
-static NEWLINE: &str = "\r\n";
-
-#[cfg(not(windows))]
-static NEWLINE: &str = "\n";
-
 pub(crate) trait Render {
     // REVIEW I doubt pushing to a String like this is the most efficient solution?
     fn render(&self, accum: &mut String);
@@ -23,11 +17,11 @@ impl Render for Module {
     fn render(&self, accum: &mut String) {
         self.imports.iter().for_each(|import| {
             import.render(accum);
-            accum.push_str(NEWLINE);
+            accum.push('\n');
         });
         self.statements.iter().for_each(|stmt| {
             stmt.render(accum);
-            accum.push_str(NEWLINE);
+            accum.push('\n');
         });
 
         accum.push_str("export {");
@@ -40,7 +34,7 @@ impl Render for Module {
                 .join(","),
         );
         accum.push_str("};");
-        accum.push_str(NEWLINE);
+        accum.push('\n');
     }
 }
 

--- a/crates/ditto-config/src/tests.rs
+++ b/crates/ditto-config/src/tests.rs
@@ -175,7 +175,7 @@ mod errors {
     }
 }
 
-#[snapshot_test::snapshot_lf(
+#[snapshot_test::snapshot(
     input = "golden-tests/parse-errors/(.*).toml",
     output = "golden-tests/parse-errors/${1}.error"
 )]

--- a/crates/ditto-cst/src/parser/tests/mod.rs
+++ b/crates/ditto-cst/src/parser/tests/mod.rs
@@ -6,7 +6,7 @@ mod r#type;
 
 use crate::{parse_header_and_imports, Module};
 
-#[snapshot_test::snapshot_lf(
+#[snapshot_test::snapshot(
     input = "golden-tests/parse-errors/(.*).ditto",
     output = "golden-tests/parse-errors/${1}.error"
 )]

--- a/crates/ditto-fmt/src/config.rs
+++ b/crates/ditto-fmt/src/config.rs
@@ -1,8 +1,2 @@
 pub static INDENT_WIDTH: u8 = 4;
 pub static MAX_WIDTH: u32 = 80;
-
-#[cfg(windows)]
-pub static NEWLINE: &str = "\r\n";
-
-#[cfg(not(windows))]
-pub static NEWLINE: &str = "\n";

--- a/crates/ditto-fmt/src/lib.rs
+++ b/crates/ditto-fmt/src/lib.rs
@@ -13,7 +13,7 @@ mod syntax;
 mod token;
 mod r#type;
 
-use config::{INDENT_WIDTH, MAX_WIDTH, NEWLINE};
+use config::{INDENT_WIDTH, MAX_WIDTH};
 
 /// Pretty-print a CST module.
 pub fn format_module(module: ditto_cst::Module) -> String {
@@ -26,7 +26,7 @@ pub fn format_module(module: ditto_cst::Module) -> String {
             indent_width: INDENT_WIDTH,
             max_width: MAX_WIDTH,
             use_tabs: false, // nah
-            new_line_text: NEWLINE,
+            new_line_text: "\n",
         },
     )
 }

--- a/crates/ditto-make/src/build_ninja.rs
+++ b/crates/ditto-make/src/build_ninja.rs
@@ -429,14 +429,14 @@ impl BuildNinja {
             variables.sort();
             for (key, value) in variables {
                 string.push_str(&format!("{} = {}", key, value));
-                string.push_str(NEWLINE);
-                string.push_str(NEWLINE);
+                string.push('\n');
+                string.push('\n');
             }
         } else {
             for (key, value) in self.variables.into_iter() {
                 string.push_str(&format!("{} = {}", key, value));
-                string.push_str(NEWLINE);
-                string.push_str(NEWLINE);
+                string.push('\n');
+                string.push('\n');
             }
         };
 
@@ -446,8 +446,8 @@ impl BuildNinja {
         }
         for rule in rules {
             string.push_str(&rule.into_syntax());
-            string.push_str(NEWLINE);
-            string.push_str(NEWLINE);
+            string.push('\n');
+            string.push('\n');
         }
 
         let mut builds = self
@@ -461,8 +461,8 @@ impl BuildNinja {
         }
         for build in builds {
             string.push_str(&build);
-            string.push_str(NEWLINE);
-            string.push_str(NEWLINE);
+            string.push('\n');
+            string.push('\n');
         }
         string
     }
@@ -511,7 +511,7 @@ impl Rule {
 
     fn into_syntax(self) -> String {
         let Self { name, command } = self;
-        format!("rule {name}{NEWLINE}  command = {command}")
+        format!("rule {name}\n  command = {command}")
     }
 }
 
@@ -619,7 +619,7 @@ impl Build {
         let mut variables = self
             .variables
             .into_iter()
-            .map(|(key, value)| format!("{NEWLINE}  {key} = {value}"))
+            .map(|(key, value)| format!("\n  {key} = {value}"))
             .collect::<Vec<_>>();
 
         if cfg!(debug_assertions) {
@@ -630,12 +630,6 @@ impl Build {
         format!("build {outputs}: {rule_name} {inputs}{variables}",)
     }
 }
-
-#[cfg(windows)]
-static NEWLINE: &str = "\r\n";
-
-#[cfg(not(windows))]
-static NEWLINE: &str = "\n";
 
 fn read_module_header_and_imports(path: &Path) -> Result<(cst::Header, Vec<cst::ImportLine>)> {
     let contents = std::fs::read_to_string(path).into_diagnostic()?;

--- a/crates/snapshot-test/README.md
+++ b/crates/snapshot-test/README.md
@@ -5,7 +5,7 @@ Cheapskate data-driven testing for the `ditto-*` crates.
 It's not _generally_ useful, yet...
 
 ```rust
-#[snapshot_test::snapshot_lf(
+#[snapshot_test::snapshot(
     input = "golden-tests/(.*).in",
     output = "golden-tests/${1}.out"
 )]

--- a/crates/snapshot-test/src/lib.rs
+++ b/crates/snapshot-test/src/lib.rs
@@ -95,6 +95,7 @@ impl TestCase {
 }
 
 #[proc_macro_attribute]
+#[deprecated]
 pub fn snapshot_lf(attrs: TokenStream, func: TokenStream) -> TokenStream {
     snapshot_impl(attrs, func, true)
 }


### PR DESCRIPTION
I'll defer to [Prettier](https://prettier.io/docs/en/options.html#end-of-line) for the reasoning 💅  But if nothing else it makes running the ditto tests across all the operating systems much easier/simpler.