### PR TITLE
Allow irrefutable patterns as function parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2590,7 +2590,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-ditto"
 version = "0.0.1"
-source = "git+https://github.com/ditto-lang/tree-sitter-ditto?rev=6b70ae4dd05c087194ecc86f473dc40f855b78bb#6b70ae4dd05c087194ecc86f473dc40f855b78bb"
+source = "git+https://github.com/ditto-lang/tree-sitter-ditto?rev=a0588121f9be33e8220a2779efa299f5e24dd79f#a0588121f9be33e8220a2779efa299f5e24dd79f"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/crates/ditto-ast/src/expression.rs
+++ b/crates/ditto-ast/src/expression.rs
@@ -20,7 +20,7 @@ pub enum Expression {
         span: Span,
 
         /// The arguments to be bound and added to the scope of `body`.
-        binders: Vec<FunctionBinder>, // REVIEW should this be a HashSet?
+        binders: Vec<(Pattern, Type)>, // REVIEW should this be a HashSet?
         // ^ NOTE we probably don't want to allow pattern matching binders in function heads
         /// The body of the function.
         body: Box<Self>,
@@ -259,7 +259,7 @@ impl Expression {
             // BUT maybe we should just store it for efficiency?
             {
                 Type::Function {
-                    parameters: binders.iter().map(|binder| binder.get_type()).collect(),
+                    parameters: binders.iter().map(|(_, t)| t.clone()).collect(),
                     return_type: Box::new(body.get_type()),
                 }
             }
@@ -344,49 +344,6 @@ impl Argument {
     pub fn get_span(&self) -> Span {
         match self {
             Self::Expression(expression) => expression.get_span(),
-        }
-    }
-}
-
-/// Binds a variable as part of a function header.
-///
-/// After (successful) type-checking we should know the type of all binders,
-/// hence all variants mention a [Type].
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum FunctionBinder {
-    /// A standard name binder.
-    Name {
-        /// The source span for this binder.
-        span: Span,
-        /// The type of this binder.
-        binder_type: Type,
-        /// The name being bound.
-        value: Name,
-    },
-    /// An unused binder (not referenced in the body of the function).
-    Unused {
-        /// The source span for this binder.
-        span: Span,
-        /// The type of this binder.
-        binder_type: Type,
-        /// The unused name.
-        value: UnusedName,
-    },
-}
-
-impl FunctionBinder {
-    /// Return the [Type] of this [FunctionBinder].
-    pub fn get_type(&self) -> Type {
-        match self {
-            Self::Name { binder_type, .. } => binder_type.clone(),
-            Self::Unused { binder_type, .. } => binder_type.clone(),
-        }
-    }
-    /// Return the source [Span] for this [FunctionBinder].
-    pub fn get_span(&self) -> Span {
-        match self {
-            Self::Name { span, .. } => *span,
-            Self::Unused { span, .. } => *span,
         }
     }
 }

--- a/crates/ditto-checker/src/result/type_error.rs
+++ b/crates/ditto-checker/src/result/type_error.rs
@@ -149,6 +149,10 @@ pub enum TypeError {
         match_span: Span,
         missing_patterns: Vec<String>,
     },
+    RefutableFunctionBinder {
+        match_span: Span,
+        missing_patterns: Vec<String>,
+    },
 }
 
 impl TypeError {
@@ -406,6 +410,14 @@ impl TypeError {
                 match_span,
                 missing_patterns,
             } => TypeErrorReport::MatchNotExhaustive {
+                input,
+                location: span_to_source_span(match_span),
+                missing_patterns: missing_patterns.join("\n"),
+            },
+            Self::RefutableFunctionBinder {
+                match_span,
+                missing_patterns,
+            } => TypeErrorReport::RefutableFunctionBinder {
                 input,
                 location: span_to_source_span(match_span),
                 missing_patterns: missing_patterns.join("\n"),
@@ -737,6 +749,15 @@ pub enum TypeErrorReport {
         #[source_code]
         input: NamedSource,
         #[label("this match expression")]
+        location: SourceSpan,
+        missing_patterns: String,
+    },
+    #[error("refutable function binder")]
+    #[diagnostic(severity(Error), help("patterns here must cover all cases"))]
+    RefutableFunctionBinder {
+        #[source_code]
+        input: NamedSource,
+        #[label("this pattern")]
         location: SourceSpan,
         missing_patterns: String,
     },

--- a/crates/ditto-checker/src/typechecker/mod.rs
+++ b/crates/ditto-checker/src/typechecker/mod.rs
@@ -292,7 +292,20 @@ pub fn infer(env: &Env, state: &mut State, expr: pre::Expression) -> Result<Expr
                     pattern_span,
                     state.substitution.apply(pattern_type.clone()),
                     vec![pattern.clone()],
-                )?;
+                )
+                .map_err(|err| {
+                    if let TypeError::MatchNotExhaustive {
+                        match_span,
+                        missing_patterns,
+                    } = err
+                    {
+                        return TypeError::RefutableFunctionBinder {
+                            match_span,
+                            missing_patterns,
+                        };
+                    }
+                    err
+                })?;
 
                 binders.push((pattern, pattern_type));
             }

--- a/crates/ditto-checker/src/typechecker/mod.rs
+++ b/crates/ditto-checker/src/typechecker/mod.rs
@@ -21,8 +21,8 @@ use crate::{
     supply::Supply,
 };
 use ditto_ast::{
-    unqualified, Argument, Effect, Expression, FunctionBinder, Kind, Name, Pattern, PrimType,
-    QualifiedName, Row, Span, Type,
+    unqualified, Argument, Effect, Expression, Kind, Name, Pattern, PrimType, QualifiedName, Row,
+    Span, Type,
 };
 use ditto_cst as cst;
 use indexmap::IndexMap;
@@ -263,69 +263,52 @@ pub fn infer(env: &Env, state: &mut State, expr: pre::Expression) -> Result<Expr
             box body,
         } => {
             let mut binders = Vec::new();
-            for binder in pre_binders {
-                match binder {
-                    pre_ast::FunctionBinder::Name {
-                        span,
-                        type_annotation,
-                        value,
-                    } => {
-                        // Check this binder doesn't conflict with existing binders
-                        let conflict = binders.iter().find_map(|binder| match binder {
-                            FunctionBinder::Name {
-                                span: found_span,
-                                value: found_value,
-                                ..
-                            } if value == *found_value => Some(*found_span),
-                            _ => None,
-                        });
-                        if let Some(previous_binder) = conflict {
-                            return Err(TypeError::DuplicateFunctionBinder {
+            let mut local_values = HashMap::new();
+
+            for (pattern, type_annotation) in pre_binders {
+                let pattern_span = pattern.get_span();
+
+                let pattern_type = type_annotation.unwrap_or_else(|| state.supply.fresh_type());
+                let pattern =
+                    check_pattern(env, state, &mut local_values, pattern_type.clone(), pattern)
+                        .map_err(|err| {
+                            if let TypeError::DuplicatePatternBinder {
                                 previous_binder,
-                                duplicate_binder: span,
-                            });
-                        }
+                                duplicate_binder,
+                            } = err
+                            {
+                                TypeError::DuplicateFunctionBinder {
+                                    previous_binder,
+                                    duplicate_binder,
+                                }
+                            } else {
+                                err
+                            }
+                        })?;
 
-                        let binder_type =
-                            type_annotation.unwrap_or_else(|| state.supply.fresh_type());
+                check_exhaustiveness(
+                    env,
+                    state,
+                    pattern_span,
+                    state.substitution.apply(pattern_type.clone()),
+                    vec![pattern.clone()],
+                )?;
 
-                        binders.push(FunctionBinder::Name {
-                            span,
-                            binder_type,
-                            value,
-                        });
-                    }
-                    pre_ast::FunctionBinder::Unused {
-                        span,
-                        type_annotation,
-                        value,
-                    } => {
-                        // REVIEW: Check this binder doesn't conflict with existing binders?
-                        let binder_type =
-                            type_annotation.unwrap_or_else(|| state.supply.fresh_type());
-
-                        binders.push(FunctionBinder::Unused {
-                            span,
-                            binder_type,
-                            value,
-                        });
-                    }
-                }
+                binders.push((pattern, pattern_type));
             }
-            let env_values = binders
-                .clone()
-                .into_iter()
-                .filter_map(LocalValue::from_function_binder)
-                .collect();
 
-            let (body, unused_spans) =
-                with_extended_env(env, state, env_values, move |env, state| {
+            let (body, unused_spans) = with_extended_env(
+                env,
+                state,
+                local_values.into_values().collect(),
+                move |env, state| {
                     if let Some(expected) = return_type_annotation {
                         check(env, state, expected, body)
                     } else {
                         infer(env, state, body)
                     }
-                })?;
+                },
+            )?;
 
             for span in unused_spans {
                 state.warnings.push(Warning::UnusedFunctionBinder { span });
@@ -1018,23 +1001,6 @@ struct LocalValue {
     span: Span,
     value_type: Type,
     name: Name,
-}
-
-impl LocalValue {
-    fn from_function_binder(binder: FunctionBinder) -> Option<Self> {
-        match binder {
-            FunctionBinder::Name {
-                span,
-                binder_type: value_type,
-                value: name,
-            } => Some(Self {
-                span,
-                value_type,
-                name,
-            }),
-            FunctionBinder::Unused { .. } => None,
-        }
-    }
 }
 
 fn with_extended_env<T>(

--- a/crates/ditto-checker/src/typechecker/substitution.rs
+++ b/crates/ditto-checker/src/typechecker/substitution.rs
@@ -1,5 +1,5 @@
 use super::common::type_variables;
-use ditto_ast::{Argument, Effect, Expression, FunctionBinder, Kind, Type};
+use ditto_ast::{Argument, Effect, Expression, Kind, Type};
 use non_empty_vec::NonEmpty;
 use std::collections::HashMap;
 
@@ -230,26 +230,7 @@ impl Substitution {
                 span,
                 binders: binders
                     .into_iter()
-                    .map(|binder| match binder {
-                        FunctionBinder::Name {
-                            span,
-                            binder_type,
-                            value,
-                        } => FunctionBinder::Name {
-                            span,
-                            binder_type: self.apply(binder_type),
-                            value,
-                        },
-                        FunctionBinder::Unused {
-                            span,
-                            binder_type,
-                            value,
-                        } => FunctionBinder::Unused {
-                            span,
-                            binder_type: self.apply(binder_type),
-                            value,
-                        },
-                    })
+                    .map(|(pattern, t)| (pattern, self.apply(t)))
                     .collect(),
                 body: Box::new(self.apply_expression(body)),
             },

--- a/crates/ditto-checker/tests/cmd/always_partial_application/test.stdout
+++ b/crates/ditto-checker/tests/cmd/always_partial_application/test.stdout
@@ -108,23 +108,25 @@
             "end_offset": 58
           },
           "binders": [
-            {
-              "Name": {
-                "span": {
-                  "start_offset": 40,
-                  "end_offset": 41
-                },
-                "binder_type": {
-                  "type": "Variable",
-                  "data": {
-                    "variable_kind": "Type",
-                    "var": 0,
-                    "source_name": null
-                  }
-                },
-                "value": "a"
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 40,
+                    "end_offset": 41
+                  },
+                  "name": "a"
+                }
+              },
+              {
+                "type": "Variable",
+                "data": {
+                  "variable_kind": "Type",
+                  "var": 0,
+                  "source_name": null
+                }
               }
-            }
+            ]
           ],
           "body": {
             "expression": "Function",
@@ -134,23 +136,25 @@
                 "end_offset": 58
               },
               "binders": [
-                {
-                  "Unused": {
-                    "span": {
-                      "start_offset": 50,
-                      "end_offset": 52
-                    },
-                    "binder_type": {
-                      "type": "Variable",
-                      "data": {
-                        "variable_kind": "Type",
-                        "var": 1,
-                        "source_name": null
-                      }
-                    },
-                    "value": "_b"
+                [
+                  {
+                    "Unused": {
+                      "span": {
+                        "start_offset": 50,
+                        "end_offset": 52
+                      },
+                      "unused_name": "_b"
+                    }
+                  },
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": "Type",
+                      "var": 1,
+                      "source_name": null
+                    }
                   }
-                }
+                ]
               ],
               "body": {
                 "expression": "LocalVariable",

--- a/crates/ditto-checker/tests/cmd/closed_record_alias/test.stdout
+++ b/crates/ditto-checker/tests/cmd/closed_record_alias/test.stdout
@@ -149,55 +149,57 @@
             "end_offset": 113
           },
           "binders": [
-            {
-              "Name": {
-                "span": {
-                  "start_offset": 89,
-                  "end_offset": 94
-                },
-                "binder_type": {
-                  "type": "ConstructorAlias",
-                  "data": {
-                    "constructor_kind": "Type",
-                    "canonical_value": {
-                      "module_name": [
-                        null,
-                        [
-                          "Test"
-                        ]
-                      ],
-                      "value": "Props"
-                    },
-                    "source_value": {
-                      "module_name": null,
-                      "value": "Props"
-                    },
-                    "alias_variables": [],
-                    "aliased_type": {
-                      "type": "RecordClosed",
-                      "data": {
-                        "kind": "Type",
-                        "row": {
-                          "a": {
-                            "type": "PrimConstructor",
-                            "data": "Int"
-                          },
-                          "b": {
-                            "type": "PrimConstructor",
-                            "data": "Bool"
-                          },
-                          "c": {
-                            "type": "PrimConstructor",
-                            "data": "Unit"
-                          }
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 89,
+                    "end_offset": 94
+                  },
+                  "name": "props"
+                }
+              },
+              {
+                "type": "ConstructorAlias",
+                "data": {
+                  "constructor_kind": "Type",
+                  "canonical_value": {
+                    "module_name": [
+                      null,
+                      [
+                        "Test"
+                      ]
+                    ],
+                    "value": "Props"
+                  },
+                  "source_value": {
+                    "module_name": null,
+                    "value": "Props"
+                  },
+                  "alias_variables": [],
+                  "aliased_type": {
+                    "type": "RecordClosed",
+                    "data": {
+                      "kind": "Type",
+                      "row": {
+                        "a": {
+                          "type": "PrimConstructor",
+                          "data": "Int"
+                        },
+                        "b": {
+                          "type": "PrimConstructor",
+                          "data": "Bool"
+                        },
+                        "c": {
+                          "type": "PrimConstructor",
+                          "data": "Unit"
                         }
                       }
                     }
                   }
-                },
-                "value": "props"
+                }
               }
-            }
+            ]
           ],
           "body": {
             "expression": "RecordAccess",

--- a/crates/ditto-checker/tests/cmd/duplicate_value_import/test.out/Foo.ast
+++ b/crates/ditto-checker/tests/cmd/duplicate_value_import/test.out/Foo.ast
@@ -81,23 +81,25 @@
             "end_offset": 71
           },
           "binders": [
-            {
-              "Name": {
-                "span": {
-                  "start_offset": 64,
-                  "end_offset": 65
-                },
-                "binder_type": {
-                  "type": "Variable",
-                  "data": {
-                    "variable_kind": "Type",
-                    "var": 0,
-                    "source_name": null
-                  }
-                },
-                "value": "a"
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 64,
+                    "end_offset": 65
+                  },
+                  "name": "a"
+                }
+              },
+              {
+                "type": "Variable",
+                "data": {
+                  "variable_kind": "Type",
+                  "var": 0,
+                  "source_name": null
+                }
               }
-            }
+            ]
           ],
           "body": {
             "expression": "LocalVariable",

--- a/crates/ditto-checker/tests/cmd/export_docs/test.stdout
+++ b/crates/ditto-checker/tests/cmd/export_docs/test.stdout
@@ -153,23 +153,25 @@
             "end_offset": 261
           },
           "binders": [
-            {
-              "Unused": {
-                "span": {
-                  "start_offset": 249,
-                  "end_offset": 250
-                },
-                "binder_type": {
-                  "type": "Variable",
-                  "data": {
-                    "variable_kind": "Type",
-                    "var": 0,
-                    "source_name": null
-                  }
-                },
-                "value": "_"
+            [
+              {
+                "Unused": {
+                  "span": {
+                    "start_offset": 249,
+                    "end_offset": 250
+                  },
+                  "unused_name": "_"
+                }
+              },
+              {
+                "type": "Variable",
+                "data": {
+                  "variable_kind": "Type",
+                  "var": 0,
+                  "source_name": null
+                }
               }
-            }
+            ]
           ],
           "body": {
             "expression": "LocalConstructor",

--- a/crates/ditto-checker/tests/cmd/float_alias/test.stdout
+++ b/crates/ditto-checker/tests/cmd/float_alias/test.stdout
@@ -69,39 +69,41 @@
             "end_offset": 171
           },
           "binders": [
-            {
-              "Name": {
-                "span": {
-                  "start_offset": 143,
-                  "end_offset": 147
-                },
-                "binder_type": {
-                  "type": "ConstructorAlias",
-                  "data": {
-                    "constructor_kind": "Type",
-                    "canonical_value": {
-                      "module_name": [
-                        null,
-                        [
-                          "Test"
-                        ]
-                      ],
-                      "value": "Number"
-                    },
-                    "source_value": {
-                      "module_name": null,
-                      "value": "Number"
-                    },
-                    "alias_variables": [],
-                    "aliased_type": {
-                      "type": "PrimConstructor",
-                      "data": "Float"
-                    }
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 143,
+                    "end_offset": 147
+                  },
+                  "name": "five"
+                }
+              },
+              {
+                "type": "ConstructorAlias",
+                "data": {
+                  "constructor_kind": "Type",
+                  "canonical_value": {
+                    "module_name": [
+                      null,
+                      [
+                        "Test"
+                      ]
+                    ],
+                    "value": "Number"
+                  },
+                  "source_value": {
+                    "module_name": null,
+                    "value": "Number"
+                  },
+                  "alias_variables": [],
+                  "aliased_type": {
+                    "type": "PrimConstructor",
+                    "data": "Float"
                   }
-                },
-                "value": "five"
+                }
               }
-            }
+            ]
           ],
           "body": {
             "expression": "LocalVariable",

--- a/crates/ditto-checker/tests/cmd/foreign_value_impl/test.stdout
+++ b/crates/ditto-checker/tests/cmd/foreign_value_impl/test.stdout
@@ -33,19 +33,21 @@
             "end_offset": 86
           },
           "binders": [
-            {
-              "Name": {
-                "span": {
-                  "start_offset": 74,
-                  "end_offset": 75
-                },
-                "binder_type": {
-                  "type": "PrimConstructor",
-                  "data": "Int"
-                },
-                "value": "n"
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 74,
+                    "end_offset": 75
+                  },
+                  "name": "n"
+                }
+              },
+              {
+                "type": "PrimConstructor",
+                "data": "Int"
               }
-            }
+            ]
           ],
           "body": {
             "expression": "LocalVariable",

--- a/crates/ditto-checker/tests/cmd/imported_constructor_matching/test.out/Dep.ast
+++ b/crates/ditto-checker/tests/cmd/imported_constructor_matching/test.out/Dep.ast
@@ -446,55 +446,57 @@
             "end_offset": 169
           },
           "binders": [
-            {
-              "Name": {
-                "span": {
-                  "start_offset": 81,
-                  "end_offset": 84
-                },
-                "binder_type": {
-                  "type": "Call",
-                  "data": {
-                    "function": {
-                      "type": "Constructor",
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 81,
+                    "end_offset": 84
+                  },
+                  "name": "abc"
+                }
+              },
+              {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "Constructor",
+                    "data": {
+                      "constructor_kind": {
+                        "Function": {
+                          "parameters": [
+                            "Type"
+                          ]
+                        }
+                      },
+                      "canonical_value": {
+                        "module_name": [
+                          null,
+                          [
+                            "Dep"
+                          ]
+                        ],
+                        "value": "ABC"
+                      },
+                      "source_value": {
+                        "module_name": null,
+                        "value": "ABC"
+                      }
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "Variable",
                       "data": {
-                        "constructor_kind": {
-                          "Function": {
-                            "parameters": [
-                              "Type"
-                            ]
-                          }
-                        },
-                        "canonical_value": {
-                          "module_name": [
-                            null,
-                            [
-                              "Dep"
-                            ]
-                          ],
-                          "value": "ABC"
-                        },
-                        "source_value": {
-                          "module_name": null,
-                          "value": "ABC"
-                        }
+                        "variable_kind": "Type",
+                        "var": 3,
+                        "source_name": null
                       }
-                    },
-                    "arguments": [
-                      {
-                        "type": "Variable",
-                        "data": {
-                          "variable_kind": "Type",
-                          "var": 3,
-                          "source_name": null
-                        }
-                      }
-                    ]
-                  }
-                },
-                "value": "abc"
+                    }
+                  ]
+                }
               }
-            }
+            ]
           ],
           "body": {
             "expression": "Match",

--- a/crates/ditto-checker/tests/cmd/imported_constructor_matching/test.stdout
+++ b/crates/ditto-checker/tests/cmd/imported_constructor_matching/test.stdout
@@ -120,55 +120,57 @@
             "end_offset": 203
           },
           "binders": [
-            {
-              "Name": {
-                "span": {
-                  "start_offset": 102,
-                  "end_offset": 105
-                },
-                "binder_type": {
-                  "type": "Call",
-                  "data": {
-                    "function": {
-                      "type": "Constructor",
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 102,
+                    "end_offset": 105
+                  },
+                  "name": "abc"
+                }
+              },
+              {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "Constructor",
+                    "data": {
+                      "constructor_kind": {
+                        "Function": {
+                          "parameters": [
+                            "Type"
+                          ]
+                        }
+                      },
+                      "canonical_value": {
+                        "module_name": [
+                          null,
+                          [
+                            "Dep"
+                          ]
+                        ],
+                        "value": "ABC"
+                      },
+                      "source_value": {
+                        "module_name": null,
+                        "value": "ABC"
+                      }
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "Variable",
                       "data": {
-                        "constructor_kind": {
-                          "Function": {
-                            "parameters": [
-                              "Type"
-                            ]
-                          }
-                        },
-                        "canonical_value": {
-                          "module_name": [
-                            null,
-                            [
-                              "Dep"
-                            ]
-                          ],
-                          "value": "ABC"
-                        },
-                        "source_value": {
-                          "module_name": null,
-                          "value": "ABC"
-                        }
+                        "variable_kind": "Type",
+                        "var": 1,
+                        "source_name": null
                       }
-                    },
-                    "arguments": [
-                      {
-                        "type": "Variable",
-                        "data": {
-                          "variable_kind": "Type",
-                          "var": 1,
-                          "source_name": null
-                        }
-                      }
-                    ]
-                  }
-                },
-                "value": "abc"
+                    }
+                  ]
+                }
               }
-            }
+            ]
           ],
           "body": {
             "expression": "Match",

--- a/crates/ditto-checker/tests/cmd/maybe_int_alias/test.stdout
+++ b/crates/ditto-checker/tests/cmd/maybe_int_alias/test.stdout
@@ -169,19 +169,21 @@
             "end_offset": 126
           },
           "binders": [
-            {
-              "Name": {
-                "span": {
-                  "start_offset": 95,
-                  "end_offset": 96
-                },
-                "binder_type": {
-                  "type": "PrimConstructor",
-                  "data": "Int"
-                },
-                "value": "i"
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 95,
+                    "end_offset": 96
+                  },
+                  "name": "i"
+                }
+              },
+              {
+                "type": "PrimConstructor",
+                "data": "Int"
               }
-            }
+            ]
           ],
           "body": {
             "expression": "Call",

--- a/crates/ditto-checker/tests/cmd/mini_vdom/test.stdout
+++ b/crates/ditto-checker/tests/cmd/mini_vdom/test.stdout
@@ -296,109 +296,113 @@
             "end_offset": 188
           },
           "binders": [
-            {
-              "Name": {
-                "span": {
-                  "start_offset": 94,
-                  "end_offset": 99
-                },
-                "binder_type": {
-                  "type": "Call",
-                  "data": {
-                    "function": {
-                      "type": "PrimConstructor",
-                      "data": "Array"
-                    },
-                    "arguments": [
-                      {
-                        "type": "Constructor",
-                        "data": {
-                          "constructor_kind": "Type",
-                          "canonical_value": {
-                            "module_name": [
-                              null,
-                              [
-                                "Test"
-                              ]
-                            ],
-                            "value": "Attr"
-                          },
-                          "source_value": {
-                            "module_name": null,
-                            "value": "Attr"
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 94,
+                    "end_offset": 99
+                  },
+                  "name": "attrs"
+                }
+              },
+              {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "PrimConstructor",
+                    "data": "Array"
+                  },
+                  "arguments": [
+                    {
+                      "type": "Constructor",
+                      "data": {
+                        "constructor_kind": "Type",
+                        "canonical_value": {
+                          "module_name": [
+                            null,
+                            [
+                              "Test"
+                            ]
+                          ],
+                          "value": "Attr"
+                        },
+                        "source_value": {
+                          "module_name": null,
+                          "value": "Attr"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 119,
+                    "end_offset": 127
+                  },
+                  "name": "children"
+                }
+              },
+              {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "PrimConstructor",
+                    "data": "Array"
+                  },
+                  "arguments": [
+                    {
+                      "type": "Call",
+                      "data": {
+                        "function": {
+                          "type": "Constructor",
+                          "data": {
+                            "constructor_kind": {
+                              "Function": {
+                                "parameters": [
+                                  {
+                                    "Variable": 1
+                                  }
+                                ]
+                              }
+                            },
+                            "canonical_value": {
+                              "module_name": [
+                                null,
+                                [
+                                  "Test"
+                                ]
+                              ],
+                              "value": "Html"
+                            },
+                            "source_value": {
+                              "module_name": null,
+                              "value": "Html"
+                            }
                           }
-                        }
-                      }
-                    ]
-                  }
-                },
-                "value": "attrs"
-              }
-            },
-            {
-              "Name": {
-                "span": {
-                  "start_offset": 119,
-                  "end_offset": 127
-                },
-                "binder_type": {
-                  "type": "Call",
-                  "data": {
-                    "function": {
-                      "type": "PrimConstructor",
-                      "data": "Array"
-                    },
-                    "arguments": [
-                      {
-                        "type": "Call",
-                        "data": {
-                          "function": {
-                            "type": "Constructor",
+                        },
+                        "arguments": [
+                          {
+                            "type": "Variable",
                             "data": {
-                              "constructor_kind": {
-                                "Function": {
-                                  "parameters": [
-                                    {
-                                      "Variable": 1
-                                    }
-                                  ]
-                                }
+                              "variable_kind": {
+                                "Variable": 1
                               },
-                              "canonical_value": {
-                                "module_name": [
-                                  null,
-                                  [
-                                    "Test"
-                                  ]
-                                ],
-                                "value": "Html"
-                              },
-                              "source_value": {
-                                "module_name": null,
-                                "value": "Html"
-                              }
+                              "var": 0,
+                              "source_name": "msg"
                             }
-                          },
-                          "arguments": [
-                            {
-                              "type": "Variable",
-                              "data": {
-                                "variable_kind": {
-                                  "Variable": 1
-                                },
-                                "var": 0,
-                                "source_name": "msg"
-                              }
-                            }
-                          ]
-                        }
+                          }
+                        ]
                       }
-                    ]
-                  }
-                },
-                "value": "children"
+                    }
+                  ]
+                }
               }
-            }
+            ]
           ],
           "body": {
             "expression": "Call",

--- a/crates/ditto-checker/tests/cmd/never/test.stdout
+++ b/crates/ditto-checker/tests/cmd/never/test.stdout
@@ -132,34 +132,36 @@
             "end_offset": 166
           },
           "binders": [
-            {
-              "Name": {
-                "span": {
-                  "start_offset": 83,
-                  "end_offset": 86
-                },
-                "binder_type": {
-                  "type": "Constructor",
-                  "data": {
-                    "constructor_kind": "Type",
-                    "canonical_value": {
-                      "module_name": [
-                        null,
-                        [
-                          "Test"
-                        ]
-                      ],
-                      "value": "Never"
-                    },
-                    "source_value": {
-                      "module_name": null,
-                      "value": "Never"
-                    }
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 83,
+                    "end_offset": 86
+                  },
+                  "name": "nah"
+                }
+              },
+              {
+                "type": "Constructor",
+                "data": {
+                  "constructor_kind": "Type",
+                  "canonical_value": {
+                    "module_name": [
+                      null,
+                      [
+                        "Test"
+                      ]
+                    ],
+                    "value": "Never"
+                  },
+                  "source_value": {
+                    "module_name": null,
+                    "value": "Never"
                   }
-                },
-                "value": "nah"
+                }
               }
-            }
+            ]
           ],
           "body": {
             "expression": "Match",

--- a/crates/ditto-checker/tests/cmd/option_alias/test.stdout
+++ b/crates/ditto-checker/tests/cmd/option_alias/test.stdout
@@ -317,23 +317,25 @@
             "end_offset": 135
           },
           "binders": [
-            {
-              "Name": {
-                "span": {
-                  "start_offset": 102,
-                  "end_offset": 103
-                },
-                "binder_type": {
-                  "type": "Variable",
-                  "data": {
-                    "variable_kind": "Type",
-                    "var": 0,
-                    "source_name": "a"
-                  }
-                },
-                "value": "a"
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 102,
+                    "end_offset": 103
+                  },
+                  "name": "a"
+                }
+              },
+              {
+                "type": "Variable",
+                "data": {
+                  "variable_kind": "Type",
+                  "var": 0,
+                  "source_name": "a"
+                }
               }
-            }
+            ]
           ],
           "body": {
             "expression": "Call",

--- a/crates/ditto-checker/tests/cmd/record_extension_newtype/test.stdout
+++ b/crates/ditto-checker/tests/cmd/record_extension_newtype/test.stdout
@@ -2233,59 +2233,61 @@
             "end_offset": 456
           },
           "binders": [
-            {
-              "Name": {
-                "span": {
-                  "start_offset": 400,
-                  "end_offset": 401
-                },
-                "binder_type": {
-                  "type": "Call",
-                  "data": {
-                    "function": {
-                      "type": "Constructor",
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 400,
+                    "end_offset": 401
+                  },
+                  "name": "e"
+                }
+              },
+              {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "Constructor",
+                    "data": {
+                      "constructor_kind": {
+                        "Function": {
+                          "parameters": [
+                            "Row"
+                          ]
+                        }
+                      },
+                      "canonical_value": {
+                        "module_name": [
+                          null,
+                          [
+                            "Test"
+                          ]
+                        ],
+                        "value": "ExtendMe"
+                      },
+                      "source_value": {
+                        "module_name": null,
+                        "value": "ExtendMe"
+                      }
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "RecordClosed",
                       "data": {
-                        "constructor_kind": {
-                          "Function": {
-                            "parameters": [
-                              "Row"
-                            ]
-                          }
-                        },
-                        "canonical_value": {
-                          "module_name": [
-                            null,
-                            [
-                              "Test"
-                            ]
-                          ],
-                          "value": "ExtendMe"
-                        },
-                        "source_value": {
-                          "module_name": null,
-                          "value": "ExtendMe"
-                        }
-                      }
-                    },
-                    "arguments": [
-                      {
-                        "type": "RecordClosed",
-                        "data": {
-                          "kind": "Type",
-                          "row": {
-                            "foo": {
-                              "type": "PrimConstructor",
-                              "data": "Int"
-                            }
+                        "kind": "Type",
+                        "row": {
+                          "foo": {
+                            "type": "PrimConstructor",
+                            "data": "Int"
                           }
                         }
                       }
-                    ]
-                  }
-                },
-                "value": "e"
+                    }
+                  ]
+                }
               }
-            }
+            ]
           ],
           "body": {
             "expression": "Match",
@@ -2427,61 +2429,63 @@
             "end_offset": 374
           },
           "binders": [
-            {
-              "Name": {
-                "span": {
-                  "start_offset": 314,
-                  "end_offset": 315
-                },
-                "binder_type": {
-                  "type": "Call",
-                  "data": {
-                    "function": {
-                      "type": "Constructor",
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 314,
+                    "end_offset": 315
+                  },
+                  "name": "e"
+                }
+              },
+              {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "Constructor",
+                    "data": {
+                      "constructor_kind": {
+                        "Function": {
+                          "parameters": [
+                            "Row"
+                          ]
+                        }
+                      },
+                      "canonical_value": {
+                        "module_name": [
+                          null,
+                          [
+                            "Test"
+                          ]
+                        ],
+                        "value": "ExtendMe"
+                      },
+                      "source_value": {
+                        "module_name": null,
+                        "value": "ExtendMe"
+                      }
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "RecordOpen",
                       "data": {
-                        "constructor_kind": {
-                          "Function": {
-                            "parameters": [
-                              "Row"
-                            ]
-                          }
-                        },
-                        "canonical_value": {
-                          "module_name": [
-                            null,
-                            [
-                              "Test"
-                            ]
-                          ],
-                          "value": "ExtendMe"
-                        },
-                        "source_value": {
-                          "module_name": null,
-                          "value": "ExtendMe"
-                        }
-                      }
-                    },
-                    "arguments": [
-                      {
-                        "type": "RecordOpen",
-                        "data": {
-                          "kind": "Type",
-                          "var": 4,
-                          "source_name": "r",
-                          "row": {
-                            "foo": {
-                              "type": "PrimConstructor",
-                              "data": "Int"
-                            }
+                        "kind": "Type",
+                        "var": 4,
+                        "source_name": "r",
+                        "row": {
+                          "foo": {
+                            "type": "PrimConstructor",
+                            "data": "Int"
                           }
                         }
                       }
-                    ]
-                  }
-                },
-                "value": "e"
+                    }
+                  ]
+                }
               }
-            }
+            ]
           ],
           "body": {
             "expression": "Match",
@@ -2627,61 +2631,63 @@
             "end_offset": 507
           },
           "binders": [
-            {
-              "Name": {
-                "span": {
-                  "start_offset": 472,
-                  "end_offset": 473
-                },
-                "binder_type": {
-                  "type": "Call",
-                  "data": {
-                    "function": {
-                      "type": "Constructor",
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 472,
+                    "end_offset": 473
+                  },
+                  "name": "e"
+                }
+              },
+              {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "Constructor",
+                    "data": {
+                      "constructor_kind": {
+                        "Function": {
+                          "parameters": [
+                            "Row"
+                          ]
+                        }
+                      },
+                      "canonical_value": {
+                        "module_name": [
+                          null,
+                          [
+                            "Test"
+                          ]
+                        ],
+                        "value": "ExtendMe"
+                      },
+                      "source_value": {
+                        "module_name": null,
+                        "value": "ExtendMe"
+                      }
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "RecordOpen",
                       "data": {
-                        "constructor_kind": {
-                          "Function": {
-                            "parameters": [
-                              "Row"
-                            ]
-                          }
-                        },
-                        "canonical_value": {
-                          "module_name": [
-                            null,
-                            [
-                              "Test"
-                            ]
-                          ],
-                          "value": "ExtendMe"
-                        },
-                        "source_value": {
-                          "module_name": null,
-                          "value": "ExtendMe"
-                        }
-                      }
-                    },
-                    "arguments": [
-                      {
-                        "type": "RecordOpen",
-                        "data": {
-                          "kind": "Type",
-                          "var": 6,
-                          "source_name": null,
-                          "row": {
-                            "foo": {
-                              "type": "PrimConstructor",
-                              "data": "Int"
-                            }
+                        "kind": "Type",
+                        "var": 6,
+                        "source_name": null,
+                        "row": {
+                          "foo": {
+                            "type": "PrimConstructor",
+                            "data": "Int"
                           }
                         }
                       }
-                    ]
-                  }
-                },
-                "value": "e"
+                    }
+                  ]
+                }
               }
-            }
+            ]
           ],
           "body": {
             "expression": "RecordAccess",

--- a/crates/ditto-checker/tests/cmd/refutable_function_binder/test.stderr
+++ b/crates/ditto-checker/tests/cmd/refutable_function_binder/test.stderr
@@ -1,0 +1,10 @@
+
+  × refutable function binder
+   ╭─[refutable_function_binder.ditto:6:1]
+ 6 │ 
+ 7 │ from_just = fn (Just(a)) -> a;
+   ·                 ───┬───
+   ·                    ╰── this pattern
+   ╰────
+  help: patterns here must cover all cases
+

--- a/crates/ditto-checker/tests/cmd/refutable_function_binder/test.stdin
+++ b/crates/ditto-checker/tests/cmd/refutable_function_binder/test.stdin
@@ -1,0 +1,7 @@
+module Test exports (..);
+
+type Maybe(a) =
+    | Just(a)
+    | Nothing;
+
+from_just = fn (Just(a)) -> a;

--- a/crates/ditto-checker/tests/cmd/refutable_function_binder/test.toml
+++ b/crates/ditto-checker/tests/cmd/refutable_function_binder/test.toml
@@ -1,0 +1,4 @@
+bin.name = "ditto-checker-testbin-check-module"
+args = ["refutable_function_binder.ditto"]
+fs.sandbox = true
+status = "failed"

--- a/crates/ditto-checker/tests/cmd/simple_value_imports/test.out/Foo.ast
+++ b/crates/ditto-checker/tests/cmd/simple_value_imports/test.out/Foo.ast
@@ -81,23 +81,25 @@
             "end_offset": 71
           },
           "binders": [
-            {
-              "Name": {
-                "span": {
-                  "start_offset": 64,
-                  "end_offset": 65
-                },
-                "binder_type": {
-                  "type": "Variable",
-                  "data": {
-                    "variable_kind": "Type",
-                    "var": 0,
-                    "source_name": null
-                  }
-                },
-                "value": "a"
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 64,
+                    "end_offset": 65
+                  },
+                  "name": "a"
+                }
+              },
+              {
+                "type": "Variable",
+                "data": {
+                  "variable_kind": "Type",
+                  "var": 0,
+                  "source_name": null
+                }
               }
-            }
+            ]
           ],
           "body": {
             "expression": "LocalVariable",

--- a/crates/ditto-checker/tests/cmd/unused_value_declaration/test.stdout
+++ b/crates/ditto-checker/tests/cmd/unused_value_declaration/test.stdout
@@ -60,23 +60,25 @@
             "end_offset": 76
           },
           "binders": [
-            {
-              "Name": {
-                "span": {
-                  "start_offset": 69,
-                  "end_offset": 70
-                },
-                "binder_type": {
-                  "type": "Variable",
-                  "data": {
-                    "variable_kind": "Type",
-                    "var": 0,
-                    "source_name": null
-                  }
-                },
-                "value": "b"
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 69,
+                    "end_offset": 70
+                  },
+                  "name": "b"
+                }
+              },
+              {
+                "type": "Variable",
+                "data": {
+                  "variable_kind": "Type",
+                  "var": 0,
+                  "source_name": null
+                }
               }
-            }
+            ]
           ],
           "body": {
             "expression": "LocalVariable",

--- a/crates/ditto-checker/tests/cmd/variable_alias/test.stdout
+++ b/crates/ditto-checker/tests/cmd/variable_alias/test.stdout
@@ -240,53 +240,46 @@
             "end_offset": 90
           },
           "binders": [
-            {
-              "Name": {
-                "span": {
-                  "start_offset": 69,
-                  "end_offset": 70
-                },
-                "binder_type": {
-                  "type": "Call",
-                  "data": {
-                    "function": {
-                      "type": "ConstructorAlias",
-                      "data": {
-                        "constructor_kind": {
-                          "Function": {
-                            "parameters": [
-                              "Type"
-                            ]
-                          }
-                        },
-                        "canonical_value": {
-                          "module_name": [
-                            null,
-                            [
-                              "Test"
-                            ]
-                          ],
-                          "value": "WhyTho"
-                        },
-                        "source_value": {
-                          "module_name": null,
-                          "value": "WhyTho"
-                        },
-                        "alias_variables": [
-                          0
-                        ],
-                        "aliased_type": {
-                          "type": "Variable",
-                          "data": {
-                            "variable_kind": "Type",
-                            "var": 0,
-                            "source_name": "a"
-                          }
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 69,
+                    "end_offset": 70
+                  },
+                  "name": "a"
+                }
+              },
+              {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "ConstructorAlias",
+                    "data": {
+                      "constructor_kind": {
+                        "Function": {
+                          "parameters": [
+                            "Type"
+                          ]
                         }
-                      }
-                    },
-                    "arguments": [
-                      {
+                      },
+                      "canonical_value": {
+                        "module_name": [
+                          null,
+                          [
+                            "Test"
+                          ]
+                        ],
+                        "value": "WhyTho"
+                      },
+                      "source_value": {
+                        "module_name": null,
+                        "value": "WhyTho"
+                      },
+                      "alias_variables": [
+                        0
+                      ],
+                      "aliased_type": {
                         "type": "Variable",
                         "data": {
                           "variable_kind": "Type",
@@ -294,12 +287,21 @@
                           "source_name": "a"
                         }
                       }
-                    ]
-                  }
-                },
-                "value": "a"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "Variable",
+                      "data": {
+                        "variable_kind": "Type",
+                        "var": 0,
+                        "source_name": "a"
+                      }
+                    }
+                  ]
+                }
               }
-            }
+            ]
           ],
           "body": {
             "expression": "LocalVariable",

--- a/crates/ditto-codegen-js/golden-tests/javascript/irrefutable_argument_patterns.ditto
+++ b/crates/ditto-codegen-js/golden-tests/javascript/irrefutable_argument_patterns.ditto
@@ -1,0 +1,16 @@
+module Test exports (..);
+
+type Wrapper(a) = Wrapper(a);
+
+unwrap = fn (Wrapper(a)) -> a;
+
+unwrap_int = fn (Wrapper(i): Wrapper(Int)): Int -> i;
+
+five = unwrap_int(Wrapper(5));
+
+type Triple(a, b, c) = Triple(a, b, c);
+
+wrappers_to_triple = fn (Wrapper(a), wrapped_b, Wrapper(c)) -> Triple(a, unwrap(wrapped_b), c);
+
+curried_wrappers_to_triple =
+    fn (Wrapper(a)) -> fn (Wrapper(b)) -> fn (Wrapper(c)) -> Triple(a, b, c);

--- a/crates/ditto-codegen-js/golden-tests/javascript/irrefutable_argument_patterns.js
+++ b/crates/ditto-codegen-js/golden-tests/javascript/irrefutable_argument_patterns.js
@@ -1,0 +1,57 @@
+function Triple($0, $1, $2) {
+  return ["Triple", $0, $1, $2];
+}
+function Wrapper($0) {
+  return ["Wrapper", $0];
+}
+function curried_wrappers_to_triple($0) {
+  if ($0[0] === "Wrapper") {
+    const a = $0[1];
+    return $0 => {
+      if ($0[0] === "Wrapper") {
+        const b = $0[1];
+        return $0 => {
+          if ($0[0] === "Wrapper") {
+            const c = $0[1];
+            return Triple(a, b, c);
+          }
+          throw new Error("Pattern match error");
+        };
+      }
+      throw new Error("Pattern match error");
+    };
+  }
+  throw new Error("Pattern match error");
+}
+function unwrap_int($0) {
+  if ($0[0] === "Wrapper") {
+    const i = $0[1];
+    return i;
+  }
+  throw new Error("Pattern match error");
+}
+const five = unwrap_int(Wrapper(5));
+function unwrap($0) {
+  if ($0[0] === "Wrapper") {
+    const a = $0[1];
+    return a;
+  }
+  throw new Error("Pattern match error");
+}
+function wrappers_to_triple($0, wrapped_b, $2) {
+  if ($0[0] === "Wrapper" && $2[0] === "Wrapper") {
+    const c = $2[1];
+    const a = $0[1];
+    return Triple(a, unwrap(wrapped_b), c);
+  }
+  throw new Error("Pattern match error");
+}
+export {
+  Triple,
+  Wrapper,
+  curried_wrappers_to_triple,
+  five,
+  unwrap,
+  unwrap_int,
+  wrappers_to_triple,
+};

--- a/crates/ditto-cst/src/ditto.lalrpop
+++ b/crates/ditto-cst/src/ditto.lalrpop
@@ -113,7 +113,7 @@ pub Expression: cst::Expression = {
 
 Expression3: cst::Expression = {
   // FIXME: why so much boxing here?
-  <fn_keyword: FnKeyword> <parameters: Box<ParensList<(FunctionParameter TypeAnnotation?)>>> <return_type_annotation: Box<ReturnTypeAnnotation?>> <right_arrow: RightArrow> <body: Box<Expression>> => cst::Expression::Function { fn_keyword, parameters, return_type_annotation, right_arrow, body },
+  <fn_keyword: FnKeyword> <parameters: Box<ParensList<(Pattern TypeAnnotation?)>>> <return_type_annotation: Box<ReturnTypeAnnotation?>> <right_arrow: RightArrow> <body: Box<Expression>> => cst::Expression::Function { fn_keyword, parameters, return_type_annotation, right_arrow, body },
 
   // match expression with | pattern -> ...
   <match_keyword: MatchKeyword> <expression: Box<Expression>> <with_keyword: WithKeyword> <head_arm: Box<MatchArm>> <tail_arms: MatchArm*> <end_keyword: EndKeyword> => cst::Expression::Match { match_keyword, expression, with_keyword, head_arm, tail_arms, end_keyword },
@@ -161,11 +161,6 @@ Expression0: cst::Expression = {
   String => cst::Expression::String(<>),
   Float => cst::Expression::Float(<>),
   Int => cst::Expression::Int(<>),
-}
-
-FunctionParameter: cst::FunctionParameter = {
-  Name => cst::FunctionParameter::Name(<>),
-  UnusedName => cst::FunctionParameter::Unused(<>),
 }
 
 ReturnTypeAnnotation: cst::TypeAnnotation = {

--- a/crates/ditto-cst/src/expression.rs
+++ b/crates/ditto-cst/src/expression.rs
@@ -20,7 +20,7 @@ pub enum Expression {
         /// `fn`
         fn_keyword: FnKeyword,
         /// The parameters to be bound and added to the scope of `body`.
-        parameters: Box<ParensList<(FunctionParameter, Option<TypeAnnotation>)>>,
+        parameters: Box<ParensList<(Pattern, Option<TypeAnnotation>)>>,
         /// Optional type annotation for `body`.
         return_type_annotation: Box<Option<TypeAnnotation>>,
         /// `->`
@@ -162,15 +162,6 @@ pub struct RecordField {
     pub equals: Equals,
     /// The value to be associated with the `label`.
     pub value: Box<Expression>,
-}
-
-/// A function expression parameter.
-#[derive(Debug, Clone)]
-pub enum FunctionParameter {
-    /// A name to be bound in the body of the function.
-    Name(Name),
-    /// A name _not_ to be bound in the body of the function.
-    Unused(UnusedName),
 }
 
 /// A binary operator.

--- a/crates/ditto-cst/src/get_span.rs
+++ b/crates/ditto-cst/src/get_span.rs
@@ -1,7 +1,7 @@
 use crate::{
-    Braces, Brackets, Expression, FunctionParameter, ModuleName, Name, PackageName, Parens,
-    Pattern, ProperName, QualifiedName, QualifiedProperName, Span, Token, Type, TypeAnnotation,
-    TypeCallFunction, UnusedName,
+    Braces, Brackets, Expression, ModuleName, Name, PackageName, Parens, Pattern, ProperName,
+    QualifiedName, QualifiedProperName, Span, Token, Type, TypeAnnotation, TypeCallFunction,
+    UnusedName,
 };
 
 impl<Value> Token<Value> {
@@ -141,16 +141,6 @@ impl Type {
                 .merge(&return_type.get_span()),
             Self::RecordClosed(braces) => braces.get_span(),
             Self::RecordOpen(braces) => braces.get_span(),
-        }
-    }
-}
-
-impl FunctionParameter {
-    /// Get the source span.
-    pub fn get_span(&self) -> Span {
-        match self {
-            Self::Name(name) => name.get_span(),
-            Self::Unused(unused_name) => unused_name.get_span(),
         }
     }
 }

--- a/crates/ditto-fmt/golden-tests/newtypes.ditto
+++ b/crates/ditto-fmt/golden-tests/newtypes.ditto
@@ -1,0 +1,16 @@
+module Newtypes exports (..);
+
+
+type Wrapped(a) = Wrapped(a);
+
+unwrap = fn (Wrapped(a)) -> a;
+
+is_wrapped_int = fn (Wrapped(_): Wrapped(Int)) -> true;
+
+never = fn (Never.Spin(never): Never.Never) -> never;
+
+both_are_nothing = fn (
+    -- testing
+    Maybe.Nothing,
+    Maybe.Nothing: Maybe(a),
+): Bool -> true;

--- a/crates/ditto-fmt/src/expression.rs
+++ b/crates/ditto-fmt/src/expression.rs
@@ -13,8 +13,7 @@ use super::{
     },
 };
 use ditto_cst::{
-    BinOp, Effect, Expression, FunctionParameter, MatchArm, Pattern, RecordField, StringToken,
-    TypeAnnotation,
+    BinOp, Effect, Expression, MatchArm, Pattern, RecordField, StringToken, TypeAnnotation,
 };
 use dprint_core::formatting::{
     condition_helpers, conditions, ir_helpers, ConditionResolver, ConditionResolverContext, Info,
@@ -163,16 +162,9 @@ pub fn gen_expression(expr: Expression, _needs_parens: bool) -> PrintItems {
         } => {
             let mut items = gen_fn_keyword(fn_keyword);
             items.extend(space());
-            items.extend(gen_parens_list(parameters, |(param, type_annotation)| {
+            items.extend(gen_parens_list(parameters, |(pattern, type_annotation)| {
                 let mut items = PrintItems::new();
-                match param {
-                    FunctionParameter::Name(name) => {
-                        items.extend(gen_name(name));
-                    }
-                    FunctionParameter::Unused(unused_name) => {
-                        items.extend(gen_unused_name(unused_name));
-                    }
-                }
+                items.extend(gen_pattern(pattern));
                 if let Some(type_annotation) = type_annotation {
                     items.extend(gen_type_annotation(type_annotation));
                 }
@@ -530,6 +522,9 @@ mod tests {
             "fn () ->\n\tif loooooooooong then\n\t\tx\n\telse\n\t\ty",
             20
         );
+
+        assert_fmt!("fn (Just(x)) -> true");
+        assert_fmt!("fn (Ok(Nothing)) -> false");
     }
 
     #[test]

--- a/crates/ditto-fmt/src/has_comments.rs
+++ b/crates/ditto-fmt/src/has_comments.rs
@@ -123,22 +123,6 @@ impl HasComments for Expression {
     }
 }
 
-impl HasComments for FunctionParameter {
-    fn has_comments(&self) -> bool {
-        match self {
-            Self::Name(name) => name.has_comments(),
-            Self::Unused(unused_name) => unused_name.has_comments(),
-        }
-    }
-
-    fn has_leading_comments(&self) -> bool {
-        match self {
-            Self::Name(name) => name.has_leading_comments(),
-            Self::Unused(unused_name) => unused_name.has_leading_comments(),
-        }
-    }
-}
-
 impl HasComments for RecordField {
     fn has_comments(&self) -> bool {
         self.label.has_comments() || self.equals.0.has_comments() || self.value.has_comments()

--- a/crates/ditto-lsp/Cargo.toml
+++ b/crates/ditto-lsp/Cargo.toml
@@ -14,7 +14,7 @@ serde = "1.0"
 serde_json = "1.0"
 log = "0.4"
 miette = { version = "4.7" }
-tree-sitter-ditto = { git = "https://github.com/ditto-lang/tree-sitter-ditto", rev = "6b70ae4dd05c087194ecc86f473dc40f855b78bb" }
+tree-sitter-ditto = { git = "https://github.com/ditto-lang/tree-sitter-ditto", rev = "a0588121f9be33e8220a2779efa299f5e24dd79f" }
 tree-sitter = "0.20"
 url = "2.2"
 ditto-cst = { path = "../ditto-cst" }


### PR DESCRIPTION
This makes working with type "wrappers" ([a.k.a `newtype`](https://wiki.haskell.org/Newtype)*) much more ergonomic by removing the need for single arm `match` expressions.

Before:

```ditto
module Wrapper exports (Wrapper, unwrap);

type Wrapper(a) = Wrapper(a);

unwrap = fn (wrapper) -> 
    match wrapper with
    | Wrapper(a) -> a
    end;
```

After:

```ditto
module Wrapper exports (Wrapper, unwrap);

type Wrapper(a) = Wrapper(a);

unwrap = fn (Wrapper(a)) -> a;
```

This becomes especially powerful once we support a richer pattern syntax 👌.


<sup>*I know "wrappers" like this aren't really newtypes as they have a runtime cost...</sup>