### PR TITLE
Support `let` bindings in `Effect` blocks

### DIFF
--- a/crates/ditto-ast/src/expression.rs
+++ b/crates/ditto-ast/src/expression.rs
@@ -397,6 +397,15 @@ pub enum Effect {
         /// Further effect statements.
         rest: Box<Self>,
     },
+    /// `do { let pattern = expression; rest }`
+    Let {
+        /// The pattern binder.
+        pattern: Pattern,
+        /// The (pure) expression to be bound.
+        expression: Box<Expression>,
+        /// Further effect statements.
+        rest: Box<Self>,
+    },
     /// `do { expression }`
     Expression {
         /// The (effectful) expression to be evaluated.

--- a/crates/ditto-checker/src/module/value_declarations/mod.rs
+++ b/crates/ditto-checker/src/module/value_declarations/mod.rs
@@ -537,6 +537,18 @@ fn toposort_value_declarations(
                     get_connected_nodes_rec_effect(rest, nodes, accum);
                 }
             }
+            cst::Effect::Let {
+                pattern,
+                expression,
+                rest,
+                ..
+            } => {
+                get_connected_nodes_rec(expression, nodes, accum);
+                let mut bound_nodes = Nodes::new();
+                get_pattern_variable_names(&mut bound_nodes, pattern);
+                let nodes = nodes.difference(&bound_nodes).cloned().collect();
+                get_connected_nodes_rec_effect(rest, &nodes, accum)
+            }
         }
     }
 

--- a/crates/ditto-checker/src/typechecker/substitution.rs
+++ b/crates/ditto-checker/src/typechecker/substitution.rs
@@ -422,6 +422,15 @@ impl Substitution {
                 expression: Box::new(self.apply_expression(expression)),
                 rest: Some(Box::new(self.apply_effect(rest))),
             },
+            Effect::Let {
+                pattern,
+                box expression,
+                box rest,
+            } => Effect::Let {
+                pattern,
+                expression: Box::new(self.apply_expression(expression)),
+                rest: Box::new(self.apply_effect(rest)),
+            },
         }
     }
 }

--- a/crates/ditto-checker/src/typechecker/tests/effect.rs
+++ b/crates/ditto-checker/src/typechecker/tests/effect.rs
@@ -14,6 +14,8 @@ fn it_typechecks_as_expected() {
         r#" fn (get_bool: Effect(Bool)) -> do { b <- get_bool; return b } "#,
         "(Effect(Bool)) -> Effect(Bool)"
     );
+
+    assert_type!(r#" do { let five : Int = 5; return five } "#, "Effect(Int)");
 }
 
 #[test]
@@ -26,6 +28,11 @@ fn it_errors_as_expected() {
 fn it_warns_as_expected() {
     assert_type!(
         "do { x <- do { return 5 }; return 10 }",
+        "Effect(Int)",
+        [UnusedEffectBinder { .. }]
+    );
+    assert_type!(
+        r#" do { let five : Int = 5; return 5 } "#,
         "Effect(Int)",
         [UnusedEffectBinder { .. }]
     );

--- a/crates/ditto-codegen-js/golden-tests/javascript/effect_expressions.ditto
+++ b/crates/ditto-codegen-js/golden-tests/javascript/effect_expressions.ditto
@@ -27,6 +27,21 @@ get_names_from_result = fn (res) -> do {
     end
 };
 
+type Wrapper(a) = Wrapped(a);
+
+get_wrapped_five = do { 
+    let five = 5;
+    return Wrapped(five) 
+};
+
+get_five: Effect(Int) = do {
+    wrapped_five <- get_wrapped_five;
+    let Wrapped(_) = wrapped_five;
+    let Wrapped(_) = wrapped_five;
+    let Wrapped(five) = wrapped_five;
+    return five
+};
+
 main : Effect(Unit) = do {
     effect_map(get_name, fn (name) -> unit)
 };

--- a/crates/ditto-codegen-js/golden-tests/javascript/effect_expressions.js
+++ b/crates/ditto-codegen-js/golden-tests/javascript/effect_expressions.js
@@ -4,6 +4,30 @@ function Err($0) {
 function Ok($0) {
   return ["Ok", $0];
 }
+function Wrapped($0) {
+  return ["Wrapped", $0];
+}
+function get_wrapped_five() {
+  const five = 5;
+  return Wrapped(five);
+}
+function get_five() {
+  const wrapped_five = get_wrapped_five();
+  const $0 = wrapped_five;
+  if ($0[0] === "Wrapped") {
+    const $1 = wrapped_five;
+    if ($1[0] === "Wrapped") {
+      const $2 = wrapped_five;
+      if ($2[0] === "Wrapped") {
+        const five = $2[1];
+        return five;
+      }
+      throw new Error("Pattern match error");
+    }
+    throw new Error("Pattern match error");
+  }
+  throw new Error("Pattern match error");
+}
 function always(_a, b) {
   return b;
 }
@@ -43,10 +67,13 @@ function get_names_from_result(res) {
 export {
   Err,
   Ok,
+  Wrapped,
   always,
   effect_map,
+  get_five,
   get_name,
   get_names,
   get_names_from_result,
+  get_wrapped_five,
   main,
 };

--- a/crates/ditto-codegen-js/golden-tests/javascript/irrefutable_argument_patterns.js
+++ b/crates/ditto-codegen-js/golden-tests/javascript/irrefutable_argument_patterns.js
@@ -7,12 +7,12 @@ function Wrapper($0) {
 function curried_wrappers_to_triple($0) {
   if ($0[0] === "Wrapper") {
     const a = $0[1];
-    return $0 => {
-      if ($0[0] === "Wrapper") {
-        const b = $0[1];
-        return $0 => {
-          if ($0[0] === "Wrapper") {
-            const c = $0[1];
+    return $1 => {
+      if ($1[0] === "Wrapper") {
+        const b = $1[1];
+        return $2 => {
+          if ($2[0] === "Wrapper") {
+            const c = $2[1];
             return Triple(a, b, c);
           }
           throw new Error("Pattern match error");
@@ -38,9 +38,9 @@ function unwrap($0) {
   }
   throw new Error("Pattern match error");
 }
-function wrappers_to_triple($0, wrapped_b, $2) {
-  if ($0[0] === "Wrapper" && $2[0] === "Wrapper") {
-    const c = $2[1];
+function wrappers_to_triple($0, wrapped_b, $1) {
+  if ($0[0] === "Wrapper" && $1[0] === "Wrapper") {
+    const c = $1[1];
     const a = $0[1];
     return Triple(a, unwrap(wrapped_b), c);
   }

--- a/crates/ditto-codegen-js/src/optimize/mod.rs
+++ b/crates/ditto-codegen-js/src/optimize/mod.rs
@@ -823,6 +823,7 @@ mod test_macros {
 
             let ast_expression = ast_module.values.into_values().next().unwrap().expression;
             let js_expression = $crate::convert::convert_expression(
+                &mut $crate::convert::Supply::default(),
                 &mut $crate::convert::ImportedModuleIdents::new(),
                 ast_expression,
             );

--- a/crates/ditto-cst/src/ditto.lalrpop
+++ b/crates/ditto-cst/src/ditto.lalrpop
@@ -188,6 +188,7 @@ Pattern: cst::Pattern = {
 
 Effect: cst::Effect = {
   <return_keyword: ReturnKeyword> <expression: Box<Expression>> => cst::Effect::Return { return_keyword, expression },
+  <let_keyword: LetKeyword> <pattern: Pattern> <type_annotation: TypeAnnotation?> <equals: Equals> <expression: Box<Expression>> <semicolon: Semicolon> <rest: Box<Effect>> => cst::Effect::Let { let_keyword, pattern, type_annotation, equals, expression, semicolon, rest },
   <expression: Box<Expression>> <rest: (Semicolon Box<Effect>)?> => cst::Effect::Expression { expression, rest },
   <name: Name> <left_arrow: LeftArrow> <expression: Box<Expression>> <semicolon: Semicolon> <rest: Box<Effect>> => cst::Effect::Bind { name, left_arrow, expression, semicolon, rest },
 }

--- a/crates/ditto-cst/src/expression.rs
+++ b/crates/ditto-cst/src/expression.rs
@@ -1,9 +1,9 @@
 use crate::{
     BracesList, BracketsList, CloseBrace, Colon, DoKeyword, Dot, ElseKeyword, EndKeyword, Equals,
-    FalseKeyword, FnKeyword, IfKeyword, LeftArrow, MatchKeyword, Name, OpenBrace, Parens,
-    ParensList, ParensList1, Pipe, QualifiedName, QualifiedProperName, ReturnKeyword, RightArrow,
-    RightPizzaOperator, Semicolon, StringToken, ThenKeyword, TrueKeyword, Type, UnitKeyword,
-    UnusedName, WithKeyword,
+    FalseKeyword, FnKeyword, IfKeyword, LeftArrow, LetKeyword, MatchKeyword, Name, OpenBrace,
+    Parens, ParensList, ParensList1, Pipe, QualifiedName, QualifiedProperName, ReturnKeyword,
+    RightArrow, RightPizzaOperator, Semicolon, StringToken, ThenKeyword, TrueKeyword, Type,
+    UnitKeyword, UnusedName, WithKeyword,
 };
 
 /// A value expression.
@@ -188,6 +188,23 @@ pub enum Effect {
         /// `<-`
         left_arrow: LeftArrow,
         /// The (effectful) expression to be evaluated.
+        expression: Box<Expression>,
+        /// `;`
+        semicolon: Semicolon,
+        /// Further effect statements.
+        rest: Box<Self>,
+    },
+    /// `do { let pattern: type_annotation = expression; rest }`
+    Let {
+        /// `return`
+        let_keyword: LetKeyword,
+        /// The binding(s)
+        pattern: Pattern,
+        /// Optional type annotation for `pattern`.
+        type_annotation: Option<TypeAnnotation>,
+        /// `=`
+        equals: Equals,
+        /// The (pure) expression to be bound.
         expression: Box<Expression>,
         /// `;`
         semicolon: Semicolon,

--- a/crates/ditto-cst/src/parser/tests/expression.rs
+++ b/crates/ditto-cst/src/parser/tests/expression.rs
@@ -401,6 +401,20 @@ fn it_parses_effect_expressions() {
             ..
         }
     );
+    assert_parses!(
+        r#" do { let fiver = ("£5"); return fiver } "#,
+        Expression::Effect {
+            effect: Effect::Let { .. },
+            ..
+        }
+    );
+    assert_parses!(
+        "do { let five : Int = 5; let Wrapper(unwrapped) = wrapped; return [five, unwrapped] }",
+        Expression::Effect {
+            effect: Effect::Let { .. },
+            ..
+        }
+    );
 }
 
 #[test]

--- a/crates/ditto-fmt/golden-tests/effect_expressions.ditto
+++ b/crates/ditto-fmt/golden-tests/effect_expressions.ditto
@@ -57,3 +57,13 @@ if_then_else_effects = do {
     else
         do_if_false()
 };
+
+let_binds = do {
+    let five = 5;
+    let another_five: Int =  -- comment
+        -- comment
+        5;
+    -- comment
+    let Wrapped(unwrapped): Wrapper(Int) = wrapped;
+    return unit
+};

--- a/crates/ditto-fmt/src/has_comments.rs
+++ b/crates/ditto-fmt/src/has_comments.rs
@@ -163,6 +163,23 @@ impl HasComments for Effect {
                     || semicolon.0.has_comments()
                     || rest.has_comments()
             }
+            Self::Let {
+                let_keyword,
+                pattern,
+                type_annotation,
+                equals,
+                expression,
+                semicolon,
+                rest,
+            } => {
+                let_keyword.0.has_comments()
+                    || pattern.has_comments()
+                    || type_annotation.has_comments()
+                    || equals.0.has_comments()
+                    || expression.has_comments()
+                    || semicolon.0.has_comments()
+                    || rest.has_comments()
+            }
             Self::Expression {
                 expression,
                 rest: None,
@@ -177,6 +194,7 @@ impl HasComments for Effect {
         match self {
             Self::Return { return_keyword, .. } => return_keyword.0.has_leading_comments(),
             Self::Bind { name, .. } => name.has_leading_comments(),
+            Self::Let { let_keyword, .. } => let_keyword.0.has_leading_comments(),
             Self::Expression { expression, .. } => expression.has_leading_comments(),
         }
     }

--- a/crates/ditto-fmt/src/token.rs
+++ b/crates/ditto-fmt/src/token.rs
@@ -42,6 +42,7 @@ gen_empty_token_like!(gen_import_keyword, cst::ImportKeyword, "import");
 gen_empty_token_like!(gen_foreign_keyword, cst::ForeignKeyword, "foreign");
 gen_empty_token_like!(gen_fn_keyword, cst::FnKeyword, "fn");
 gen_empty_token_like!(gen_end_keyword, cst::EndKeyword, "end");
+gen_empty_token_like!(gen_let_keyword, cst::LetKeyword, "let");
 gen_empty_token_like!(gen_open_bracket, cst::OpenBracket, "[");
 gen_empty_token_like!(gen_open_brace, cst::OpenBrace, "{");
 gen_empty_token_like!(gen_pipe, cst::Pipe, "|");


### PR DESCRIPTION
This allows pure variable binding in `Effect` blocks. For example:

```ditto
main = do {
    let five: Int = 5;
    return five
};
```

Of course the above is a bit redundant (and should probably be rewritten as part of the JS codegen 👀 ) but this is useful in less trivial cases.

It's particularly useful as [we don't currently support patterns on the left-hand side of effect binds](https://github.com/ditto-lang/ditto/issues/59#issuecomment-1298362282) (`<-`, due to parsing restrictions).

So eventually this will be nice for code like:

```ditto
main = do {
    env <- get_env();
    let { foo } = env;
    return foo
};
```

Also note that as part of this I had to add a fresh variable `supply` to the JavaSCript code generator, so that we can use generated variables without risking bad `const` assignments (i.e. `Identifier 'x' has already been declared`).