### PR TITLE
Record updates 👌

### DIFF
--- a/crates/ditto-ast/src/expression.rs
+++ b/crates/ditto-ast/src/expression.rs
@@ -200,6 +200,17 @@ pub enum Expression {
         /// The record label being accessed.
         label: Name,
     },
+    /// `{ target | label = value }`
+    RecordUpdate {
+        /// The source span for this expression.
+        span: Span,
+        /// The type of the entire record being updated.
+        record_type: Type,
+        /// The expression being updated.
+        target: Box<Self>,
+        /// The record updates.
+        fields: IndexMap<Name, Self>,
+    },
     /// An array literal.
     Array {
         /// The source span for this expression.
@@ -279,6 +290,7 @@ impl Expression {
             Self::ForeignVariable { variable_type, .. } => variable_type.clone(),
             Self::ImportedVariable { variable_type, .. } => variable_type.clone(),
             Self::RecordAccess { field_type, .. } => field_type.clone(),
+            Self::RecordUpdate { record_type, .. } => record_type.clone(),
             Self::Array { value_type, .. } => value_type.clone(),
             Self::Record { fields, .. } => Type::RecordClosed {
                 kind: Kind::Type,
@@ -309,6 +321,7 @@ impl Expression {
             Self::ImportedVariable { span, .. } => *span,
             Self::Effect { span, .. } => *span,
             Self::RecordAccess { span, .. } => *span,
+            Self::RecordUpdate { span, .. } => *span,
             Self::String { span, .. } => *span,
             Self::Int { span, .. } => *span,
             Self::Float { span, .. } => *span,

--- a/crates/ditto-checker/src/module/value_declarations/mod.rs
+++ b/crates/ditto-checker/src/module/value_declarations/mod.rs
@@ -489,6 +489,14 @@ fn toposort_value_declarations(
             Expression::RecordAccess { target, .. } => {
                 get_connected_nodes_rec(target, nodes, accum);
             }
+            Expression::RecordUpdate {
+                target, updates, ..
+            } => {
+                get_connected_nodes_rec(target, nodes, accum);
+                updates.iter().for_each(|cst::RecordField { value, .. }| {
+                    get_connected_nodes_rec(value, nodes, accum);
+                })
+            }
             Expression::Parens(parens) => {
                 get_connected_nodes_rec(&parens.value, nodes, accum);
             }

--- a/crates/ditto-checker/src/typechecker/substitution.rs
+++ b/crates/ditto-checker/src/typechecker/substitution.rs
@@ -350,6 +350,20 @@ impl Substitution {
                 target: Box::new(self.apply_expression(target)),
                 label,
             },
+            RecordUpdate {
+                span,
+                record_type,
+                box target,
+                fields,
+            } => RecordUpdate {
+                span,
+                record_type: self.apply(record_type),
+                target: Box::new(self.apply_expression(target)),
+                fields: fields
+                    .into_iter()
+                    .map(|(label, expr)| (label, self.apply_expression(expr)))
+                    .collect(),
+            },
             True { span, value_type } => True {
                 span,
                 value_type: self.apply(value_type),

--- a/crates/ditto-codegen-js/src/ast.rs
+++ b/crates/ditto-codegen-js/src/ast.rs
@@ -165,8 +165,12 @@ pub enum Expression {
     IndexAccess { target: Box<Self>, index: Box<Self> },
     /// ```javascript
     /// { "key": value }
+    /// { ...expr, "key": value }
     /// ```
-    Object(indexmap::IndexMap<String, Self>),
+    Object {
+        spread: Option<Box<Self>>,
+        entries: indexmap::IndexMap<String, Self>,
+    },
 }
 
 /// A binary operator.

--- a/crates/ditto-codegen-js/src/convert.rs
+++ b/crates/ditto-codegen-js/src/convert.rs
@@ -520,7 +520,28 @@ pub(crate) fn convert_expression(
                     )
                 })
                 .collect();
-            Expression::Object(entries)
+            Expression::Object {
+                spread: None,
+                entries,
+            }
+        }
+        ditto_ast::Expression::RecordUpdate {
+            box target, fields, ..
+        } => {
+            let spread = Box::new(convert_expression(supply, imported_module_idents, target));
+            let entries = fields
+                .into_iter()
+                .map(|(name, expr)| {
+                    (
+                        name.0,
+                        convert_expression(supply, imported_module_idents, expr),
+                    )
+                })
+                .collect();
+            Expression::Object {
+                spread: Some(spread),
+                entries,
+            }
         }
     }
 }

--- a/crates/ditto-codegen-js/src/render.rs
+++ b/crates/ditto-codegen-js/src/render.rs
@@ -238,8 +238,13 @@ impl Render for Expression {
                 index.render(accum);
                 accum.push(']');
             }
-            Self::Object(entries) => {
+            Self::Object { spread, entries } => {
                 accum.push('{');
+                if let Some(box spread) = spread {
+                    accum.push_str("...(");
+                    spread.render(accum);
+                    accum.push_str("),");
+                }
                 let len = entries.len();
                 for (i, (key, value)) in entries.iter().enumerate() {
                     accum.push('"');

--- a/crates/ditto-codegen-js/tests/golden/objects.ditto
+++ b/crates/ditto-codegen-js/tests/golden/objects.ditto
@@ -14,3 +14,12 @@ foo = mk_has_foo(true).foo;
 
 pure_object = fn () -> {};
 do_object = do { return {} };
+
+update_foo_bar = fn (r) -> { r | foo = 1, bar = 2 };
+
+deep_update = fn (r) -> 
+    { r | a = 
+        { r.a | b = 
+            { r.a.b | c = true } 
+        } 
+    };

--- a/crates/ditto-codegen-js/tests/golden/objects.js
+++ b/crates/ditto-codegen-js/tests/golden/objects.js
@@ -1,3 +1,9 @@
+function deep_update(r) {
+  return { ...r, a: { ...r["a"], b: { ...r["a"]["b"], c: true } } };
+}
+function update_foo_bar(r) {
+  return { ...r, foo: 1, bar: 2 };
+}
 function do_object() {
   return {};
 }
@@ -17,6 +23,7 @@ const just_object_things = { yep: true, huh: undefined, why: () => ({}) };
 const empty_object = {};
 export {
   d,
+  deep_update,
   do_object,
   empty_object,
   foo,
@@ -24,5 +31,6 @@ export {
   just_object_things,
   mk_has_foo,
   pure_object,
+  update_foo_bar,
   very_nested,
 };

--- a/crates/ditto-cst/src/ditto.lalrpop
+++ b/crates/ditto-cst/src/ditto.lalrpop
@@ -153,6 +153,10 @@ Expression0: cst::Expression = {
 
   Parens<Box<Expression>> => cst::Expression::Parens(<>),
   BracesList<RecordField> => cst::Expression::Record(<>),
+
+  // `{ Some.record | foo = bar }`
+  <open_brace: OpenBrace> <target: Box<Expression1>> <pipe: Pipe> <updates: CommaSep1<RecordField>> <close_brace: CloseBrace> => cst::Expression::RecordUpdate { open_brace, target, pipe, updates, close_brace },
+
   TrueKeyword => cst::Expression::True(<>),
   FalseKeyword => cst::Expression::False(<>),
   UnitKeyword => cst::Expression::Unit(<>),

--- a/crates/ditto-cst/src/expression.rs
+++ b/crates/ditto-cst/src/expression.rs
@@ -1,9 +1,9 @@
 use crate::{
-    BracesList, BracketsList, CloseBrace, Colon, DoKeyword, Dot, ElseKeyword, EndKeyword, Equals,
-    FalseKeyword, FnKeyword, IfKeyword, LeftArrow, LetKeyword, MatchKeyword, Name, OpenBrace,
-    Parens, ParensList, ParensList1, Pipe, QualifiedName, QualifiedProperName, ReturnKeyword,
-    RightArrow, RightPizzaOperator, Semicolon, StringToken, ThenKeyword, TrueKeyword, Type,
-    UnitKeyword, UnusedName, WithKeyword,
+    BracesList, BracketsList, CloseBrace, Colon, CommaSep1, DoKeyword, Dot, ElseKeyword,
+    EndKeyword, Equals, FalseKeyword, FnKeyword, IfKeyword, LeftArrow, LetKeyword, MatchKeyword,
+    Name, OpenBrace, Parens, ParensList, ParensList1, Pipe, QualifiedName, QualifiedProperName,
+    ReturnKeyword, RightArrow, RightPizzaOperator, Semicolon, StringToken, ThenKeyword,
+    TrueKeyword, Type, UnitKeyword, UnusedName, WithKeyword,
 };
 
 /// A value expression.
@@ -150,6 +150,19 @@ pub enum Expression {
         dot: Dot,
         /// Label of the field being accessed.
         label: Name,
+    },
+    /// `{ target | label = value }`
+    RecordUpdate {
+        /// `{`
+        open_brace: OpenBrace,
+        /// The record expression being updated.
+        target: Box<Self>,
+        /// `|`
+        pipe: Pipe,
+        /// Record fields to be updated.
+        updates: CommaSep1<RecordField>,
+        /// `}`
+        close_brace: CloseBrace,
     },
 }
 

--- a/crates/ditto-cst/src/get_span.rs
+++ b/crates/ditto-cst/src/get_span.rs
@@ -113,6 +113,11 @@ impl Expression {
             Self::Unit(unit_keyword) => unit_keyword.0.get_span(),
             Self::BinOp { lhs, rhs, .. } => lhs.get_span().merge(&rhs.get_span()),
             Self::RecordAccess { target, label, .. } => target.get_span().merge(&label.get_span()),
+            Self::RecordUpdate {
+                open_brace,
+                close_brace,
+                ..
+            } => open_brace.0.get_span().merge(&close_brace.0.get_span()),
         }
     }
 }

--- a/crates/ditto-cst/src/parser/tests/expression.rs
+++ b/crates/ditto-cst/src/parser/tests/expression.rs
@@ -552,3 +552,13 @@ fn it_parses_record_access() {
         }
     );
 }
+
+#[test]
+fn it_parses_record_updates() {
+    assert_parses!("{ r | foo = 2 }", Expression::RecordUpdate { .. });
+    assert_parses!("{ Mod.r | foo = 2 }", Expression::RecordUpdate { .. });
+    assert_parses!(
+        "{ r | foo = 2, bar = unit, }",
+        Expression::RecordUpdate { .. }
+    );
+}

--- a/crates/ditto-fmt/src/has_comments.rs
+++ b/crates/ditto-fmt/src/has_comments.rs
@@ -96,6 +96,19 @@ impl HasComments for Expression {
                     || braces.value.has_comments()
                     || braces.close_brace.0.has_comments()
             }
+            Self::RecordUpdate {
+                open_brace,
+                target,
+                pipe,
+                updates,
+                close_brace,
+            } => {
+                open_brace.0.has_comments()
+                    || target.has_comments()
+                    || pipe.0.has_comments()
+                    || updates.has_comments()
+                    || close_brace.0.has_comments()
+            }
         }
     }
 
@@ -119,6 +132,7 @@ impl HasComments for Expression {
             Self::BinOp { lhs, .. } => lhs.has_leading_comments(),
             Self::RecordAccess { target, .. } => target.has_leading_comments(),
             Self::Record(braces) => braces.open_brace.0.has_leading_comments(),
+            Self::RecordUpdate { open_brace, .. } => open_brace.0.has_leading_comments(),
         }
     }
 }

--- a/crates/ditto-fmt/src/syntax.rs
+++ b/crates/ditto-fmt/src/syntax.rs
@@ -85,10 +85,14 @@ where
     GenElement: FnOnce(T) -> PrintItems + Copy,
 {
     let mut items = PrintItems::new();
-
+    let parens_have_inner_comments =
+        parens.open_paren.0.has_trailing_comment() || parens.close_paren.0.has_leading_comments();
     items.extend(gen_open_paren(parens.open_paren));
-    let gen_separated_values_result =
-        gen_comma_sep1(parens.value, gen_element, force_use_new_lines);
+    let gen_separated_values_result = gen_comma_sep1(
+        parens.value,
+        gen_element,
+        force_use_new_lines || parens_have_inner_comments,
+    );
     let element_items = gen_separated_values_result.items;
     items.extend(element_items);
     items.extend(gen_close_paren(parens.close_paren));
@@ -104,9 +108,12 @@ where
     GenElement: FnOnce(T) -> PrintItems + Copy,
 {
     let mut items = PrintItems::new();
+    let brackets_have_inner_comments = brackets.open_bracket.0.has_trailing_comment()
+        || brackets.close_bracket.0.has_leading_comments();
     items.extend(gen_open_bracket(brackets.open_bracket));
     if let Some(elements) = brackets.value {
-        let gen_separated_values_result = gen_comma_sep1(elements, gen_element, false);
+        let gen_separated_values_result =
+            gen_comma_sep1(elements, gen_element, brackets_have_inner_comments);
         let element_items = gen_separated_values_result.items;
         items.extend(element_items);
     }
@@ -120,9 +127,12 @@ where
     GenElement: FnOnce(T) -> PrintItems + Copy,
 {
     let mut items = PrintItems::new();
+    let braces_have_inner_comments =
+        braces.open_brace.0.has_trailing_comment() || braces.close_brace.0.has_leading_comments();
     items.extend(gen_open_brace(braces.open_brace));
     if let Some(elements) = braces.value {
-        let gen_separated_values_result = gen_comma_sep1(elements, gen_element, false);
+        let gen_separated_values_result =
+            gen_comma_sep1(elements, gen_element, braces_have_inner_comments);
 
         let is_multiple_lines = gen_separated_values_result.is_multi_line_condition_ref;
         items.push_condition(conditions::if_false(

--- a/crates/ditto-fmt/tests/golden/value_declarations.ditto
+++ b/crates/ditto-fmt/tests/golden/value_declarations.ditto
@@ -15,3 +15,12 @@ hanging_fives = [
 ];
 
 foreign some_npm_function: (Int) -> Int;
+
+update_fields = fn (r) ->
+    -- updates a bunch of things
+    {
+        -- specifically...
+        r |
+            foo = 2,
+            bar = { Stuff.r | baz = r.baz },
+    };


### PR DESCRIPTION
The language now supports: 

```ditto
{ some_record | foo = 2, bar = false }
```

Where `some_record` can be `Expression1` or `Expression0`.

https://github.com/ditto-lang/ditto/blob/b1346ff51de876ae9eab3fdd4d3df96df3e92915/crates/ditto-cst/src/ditto.lalrpop#L138-L164

**Note** that record updates a) do not support adding new fields to a record and b) do not support changing the type of an existing record field. These choices are stolen from [Erlang](https://www.erlang.org/doc/efficiency_guide/maps.html#using-maps-as-an-alternative-to-records) and [Elm](https://github.com/elm/compiler/blob/047d5026fe6547c842db65f7196fed3f0b4743ee/docs/upgrade-instructions/0.19.0.md#stricter-record-update-syntax).