### PR TITLE
Add `let` expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2803,7 +2803,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-ditto"
 version = "0.0.1"
-source = "git+https://github.com/ditto-lang/tree-sitter-ditto?rev=d2a30bc3aab2a4c4502e8b6d192aa648bacd84a4#d2a30bc3aab2a4c4502e8b6d192aa648bacd84a4"
+source = "git+https://github.com/ditto-lang/tree-sitter-ditto?rev=06f09cc4a923fa656381949a0952df863bbc3170#06f09cc4a923fa656381949a0952df863bbc3170"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/crates/ditto-ast/src/expression.rs
+++ b/crates/ditto-ast/src/expression.rs
@@ -145,6 +145,15 @@ pub enum Expression {
         /// The chain of effect statements.
         effect: Effect,
     },
+    /// An expression with a value added to scope.
+    Let {
+        /// The source span for this expression.
+        span: Span,
+        /// The declaration to be added to the scope.
+        declaration: LetValueDeclaration,
+        /// The expression with a new value in scope.
+        expression: Box<Expression>,
+    },
     /// A string literal.
     String {
         /// The source span for this expression.
@@ -299,6 +308,7 @@ impl Expression {
                     .map(|(label, element)| (label.clone(), element.get_type()))
                     .collect(),
             },
+            Self::Let { expression, .. } => expression.get_type(),
             Self::String { value_type, .. } => value_type.clone(),
             Self::Int { value_type, .. } => value_type.clone(),
             Self::Float { value_type, .. } => value_type.clone(),
@@ -322,6 +332,7 @@ impl Expression {
             Self::Effect { span, .. } => *span,
             Self::RecordAccess { span, .. } => *span,
             Self::RecordUpdate { span, .. } => *span,
+            Self::Let { span, .. } => *span,
             Self::String { span, .. } => *span,
             Self::Int { span, .. } => *span,
             Self::Float { span, .. } => *span,
@@ -431,4 +442,15 @@ pub enum Effect {
         /// The expression to be returned.
         expression: Box<Expression>,
     },
+}
+
+/// A value declaration that appears within a `let` expression.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LetValueDeclaration {
+    /// The pattern containing names to be bound.
+    pub pattern: Pattern,
+    /// The type of the expression being bound.
+    pub expression_type: Type,
+    /// The expression being bound.
+    pub expression: Box<Expression>,
 }

--- a/crates/ditto-checker/src/result/warnings.rs
+++ b/crates/ditto-checker/src/result/warnings.rs
@@ -35,6 +35,9 @@ pub enum Warning {
     UnusedEffectBinder {
         span: Span,
     },
+    UnusedLetBinder {
+        span: Span,
+    },
     UnusedValueDeclaration {
         span: Span,
     },
@@ -94,6 +97,9 @@ impl Warning {
                 location: span_to_source_span(span),
             },
             Self::UnusedEffectBinder { span } => WarningReport::UnusedEffectBinder {
+                location: span_to_source_span(span),
+            },
+            Self::UnusedLetBinder { span } => WarningReport::UnusedLetBinder {
                 location: span_to_source_span(span),
             },
             Self::UnusedValueDeclaration { span } => WarningReport::UnusedValueDeclaration {
@@ -182,6 +188,13 @@ pub enum WarningReport {
     #[error("unused effect binder")]
     #[diagnostic(severity(Warning))]
     UnusedEffectBinder {
+        #[label("this isn't used")]
+        #[serde(with = "SourceSpanDef")]
+        location: SourceSpan,
+    },
+    #[error("unused let binder")]
+    #[diagnostic(severity(Warning))]
+    UnusedLetBinder {
         #[label("this isn't used")]
         #[serde(with = "SourceSpanDef")]
         location: SourceSpan,

--- a/crates/ditto-checker/src/typechecker/substitution.rs
+++ b/crates/ditto-checker/src/typechecker/substitution.rs
@@ -1,5 +1,5 @@
 use super::common::type_variables;
-use ditto_ast::{Argument, Effect, Expression, Kind, Type};
+use ditto_ast::{Argument, Effect, Expression, Kind, LetValueDeclaration, Type};
 use non_empty_vec::NonEmpty;
 use std::collections::HashMap;
 
@@ -363,6 +363,24 @@ impl Substitution {
                     .into_iter()
                     .map(|(label, expr)| (label, self.apply_expression(expr)))
                     .collect(),
+            },
+            Let {
+                span,
+                declaration:
+                    LetValueDeclaration {
+                        pattern: decl_pattern,
+                        expression_type: decl_type,
+                        expression: box decl_expr,
+                    },
+                box expression,
+            } => Let {
+                span,
+                declaration: LetValueDeclaration {
+                    pattern: decl_pattern,
+                    expression_type: self.apply(decl_type),
+                    expression: Box::new(self.apply_expression(decl_expr)),
+                },
+                expression: Box::new(self.apply_expression(expression)),
             },
             True { span, value_type } => True {
                 span,

--- a/crates/ditto-checker/src/typechecker/tests/let.rs
+++ b/crates/ditto-checker/src/typechecker/tests/let.rs
@@ -1,0 +1,16 @@
+use super::macros::*;
+use crate::Warning::*;
+
+#[test]
+fn it_typechecks_as_expected() {
+    assert_type!("let five : Int = 5; in five", "Int");
+    assert_type!(
+        "let five : Int = 5; fives = [five, five, five]; in fives",
+        "Array(Int)"
+    );
+}
+
+#[test]
+fn it_warns_as_expected() {
+    assert_type!("let five = 5; in unit", "Unit", [UnusedLetBinder { .. }]);
+}

--- a/crates/ditto-checker/src/typechecker/tests/mod.rs
+++ b/crates/ditto-checker/src/typechecker/tests/mod.rs
@@ -6,6 +6,7 @@ mod effect;
 mod float;
 mod function;
 mod int;
+mod r#let;
 pub(self) mod macros;
 mod r#match;
 mod records;

--- a/crates/ditto-checker/src/typechecker/toposort.rs
+++ b/crates/ditto-checker/src/typechecker/toposort.rs
@@ -1,0 +1,296 @@
+use ditto_ast::graph::{toposort, toposort_deterministic, Scc};
+use ditto_cst as cst;
+use std::collections::HashSet;
+
+type Node = String;
+type Nodes = HashSet<String>;
+
+pub fn toposort_value_declarations(
+    cst_value_declarations: Vec<cst::ValueDeclaration>,
+) -> Vec<Scc<cst::ValueDeclaration>> {
+    let declaration_names: Nodes = cst_value_declarations.iter().map(get_key).collect();
+
+    if cfg!(debug_assertions) {
+        return toposort_deterministic(
+            cst_value_declarations,
+            get_key,
+            |declaration: &cst::ValueDeclaration| -> Nodes {
+                let mut accum = Nodes::new();
+                get_connected_nodes_rec(&declaration.expression, &declaration_names, &mut accum);
+                accum
+            },
+            // Sort by name
+            |a, b| a.name.0.value.cmp(&b.name.0.value),
+        );
+    } else {
+        return toposort(
+            cst_value_declarations,
+            get_key,
+            |declaration: &cst::ValueDeclaration| -> Nodes {
+                let mut accum = Nodes::new();
+                get_connected_nodes_rec(&declaration.expression, &declaration_names, &mut accum);
+                accum
+            },
+        );
+    }
+}
+
+fn get_key(declaration: &cst::ValueDeclaration) -> Node {
+    declaration.name.0.value.clone()
+}
+
+fn get_connected_nodes_rec(expression: &cst::Expression, nodes: &Nodes, accum: &mut Nodes) {
+    use cst::{Expression, Qualified};
+    match expression {
+        Expression::Variable(Qualified {
+            module_name, value, ..
+        }) => {
+            if module_name.is_some() {
+                // If it's imported then it's not interesting here
+                //
+                // REVIEW: what if it's imported unqualified? e.g.
+                //
+                //    import Foo (foo);
+                //    foo = foo;
+                //          ^^^ is this refering to to imported `foo` or is it a cyclic reference?
+                return;
+            }
+            let node = &value.0.value;
+            if nodes.contains(node) && !accum.contains(node) {
+                accum.insert(node.clone());
+            }
+        }
+        Expression::Call {
+            function,
+            arguments,
+        } => {
+            get_connected_nodes_rec(function, nodes, accum);
+            if let Some(arguments) = arguments.value.to_owned() {
+                arguments.iter().for_each(|arg| {
+                    get_connected_nodes_rec(arg, nodes, accum);
+                })
+            }
+        }
+        Expression::Function {
+            parameters, body, ..
+        } => {
+            if let Some(ref parameters) = parameters.value {
+                let mut bound_nodes = Nodes::new();
+                for (pattern, _) in parameters.iter() {
+                    get_pattern_variable_names(&mut bound_nodes, pattern)
+                }
+                let nodes = nodes.difference(&bound_nodes).cloned().collect();
+                get_connected_nodes_rec(body, &nodes, accum)
+            } else {
+                get_connected_nodes_rec(body, nodes, accum)
+            }
+        }
+        Expression::If {
+            condition,
+            true_clause,
+            false_clause,
+            ..
+        } => {
+            get_connected_nodes_rec(condition, nodes, accum);
+            get_connected_nodes_rec(true_clause, nodes, accum);
+            get_connected_nodes_rec(false_clause, nodes, accum);
+        }
+        Expression::Match {
+            expression,
+            head_arm,
+            tail_arms,
+            ..
+        } => {
+            get_connected_nodes_rec(expression, nodes, accum);
+            get_connected_nodes_rec(&head_arm.expression, nodes, accum);
+            for tail_arm in tail_arms.iter() {
+                get_connected_nodes_rec(&tail_arm.expression, nodes, accum);
+            }
+        }
+        Expression::Effect { effect, .. } => {
+            get_connected_nodes_rec_effect(effect, nodes, accum);
+        }
+        Expression::Array(elements) => {
+            if let Some(ref elements) = elements.value {
+                elements.iter().for_each(|element| {
+                    get_connected_nodes_rec(element, nodes, accum);
+                })
+            }
+        }
+        Expression::Record(fields) => {
+            if let Some(ref fields) = fields.value {
+                fields.iter().for_each(|cst::RecordField { value, .. }| {
+                    get_connected_nodes_rec(value, nodes, accum);
+                })
+            }
+        }
+        Expression::RecordAccess { target, .. } => {
+            get_connected_nodes_rec(target, nodes, accum);
+        }
+        Expression::RecordUpdate {
+            target, updates, ..
+        } => {
+            get_connected_nodes_rec(target, nodes, accum);
+            updates.iter().for_each(|cst::RecordField { value, .. }| {
+                get_connected_nodes_rec(value, nodes, accum);
+            })
+        }
+        Expression::Parens(parens) => {
+            get_connected_nodes_rec(&parens.value, nodes, accum);
+        }
+        Expression::BinOp {
+            box lhs,
+            operator: _,
+            box rhs,
+        } => {
+            get_connected_nodes_rec(lhs, nodes, accum);
+            get_connected_nodes_rec(rhs, nodes, accum);
+        }
+        Expression::Let {
+            head_declaration,
+            tail_declarations,
+            expr,
+            ..
+        } => {
+            // NOTE: the below implies that all names introduced by let bindings
+            // immediately shadow any existing ones.
+            let mut bound_nodes = Nodes::new();
+            get_pattern_variable_names(&mut bound_nodes, &head_declaration.pattern);
+            for decl in tail_declarations {
+                get_pattern_variable_names(&mut bound_nodes, &decl.pattern);
+            }
+            let nodes = nodes.difference(&bound_nodes).cloned().collect();
+
+            get_connected_nodes_rec(&head_declaration.expression, &nodes, accum);
+            for decl in tail_declarations {
+                get_connected_nodes_rec(&decl.expression, &nodes, accum);
+            }
+            get_connected_nodes_rec(expr, &nodes, accum);
+        }
+        // noop
+        Expression::Constructor(_qualified_proper_name) => {}
+        Expression::String(_) => {}
+        Expression::Int(_) => {}
+        Expression::Float(_) => {}
+        Expression::True(_) => {}
+        Expression::False(_) => {}
+        Expression::Unit(_) => {}
+    }
+}
+
+fn get_connected_nodes_rec_effect(effect: &cst::Effect, nodes: &Nodes, accum: &mut Nodes) {
+    match effect {
+        cst::Effect::Return {
+            return_keyword: _,
+            box expression,
+        } => get_connected_nodes_rec(expression, nodes, accum),
+        cst::Effect::Bind {
+            name,
+            left_arrow: _,
+            box expression,
+            semicolon: _,
+            rest,
+        } => {
+            get_connected_nodes_rec(expression, nodes, accum);
+            let nodes = nodes
+                .difference(&HashSet::from([name.0.value.clone()]))
+                .cloned()
+                .collect();
+            get_connected_nodes_rec_effect(rest, &nodes, accum);
+        }
+        cst::Effect::Expression { expression, rest } => {
+            get_connected_nodes_rec(expression, nodes, accum);
+            if let Some((_semicolon, rest)) = rest {
+                get_connected_nodes_rec_effect(rest, nodes, accum);
+            }
+        }
+        cst::Effect::Let {
+            pattern,
+            expression,
+            rest,
+            ..
+        } => {
+            get_connected_nodes_rec(expression, nodes, accum);
+            let mut bound_nodes = Nodes::new();
+            get_pattern_variable_names(&mut bound_nodes, pattern);
+            let nodes = nodes.difference(&bound_nodes).cloned().collect();
+            get_connected_nodes_rec_effect(rest, &nodes, accum)
+        }
+    }
+}
+
+fn get_pattern_variable_names(nodes: &mut Nodes, pattern: &cst::Pattern) {
+    match pattern {
+        cst::Pattern::NullaryConstructor { constructor: _ } => {}
+        cst::Pattern::Constructor {
+            constructor: _,
+            arguments: cst::Parens {
+                value: parameters, ..
+            },
+        } => {
+            for box pattern in parameters.iter() {
+                get_pattern_variable_names(nodes, pattern)
+            }
+        }
+        cst::Pattern::Variable { name } => {
+            nodes.insert(name.0.value.clone());
+        }
+        cst::Pattern::Unused { unused_name: _ } => {}
+    }
+}
+#[cfg(test)]
+mod tests {
+    macro_rules! parse_value_declaration {
+        ($decl:expr) => {{
+            let parse_result = ditto_cst::ValueDeclaration::parse(&format!("{};", $decl));
+            assert!(
+                matches!(parse_result, Ok(_)),
+                "{:#?}",
+                parse_result.unwrap_err()
+            );
+            parse_result.unwrap()
+        }};
+    }
+
+    macro_rules! assert_toposort {
+        ($decls:expr, $want:expr) => {{
+            let mut cst_value_declarations = Vec::new();
+            for decl in $decls {
+                cst_value_declarations.push(parse_value_declaration!(decl));
+            }
+            let toposorted =
+                crate::typechecker::toposort::toposort_value_declarations(cst_value_declarations);
+            assert_eq!(
+                toposorted
+                    .into_iter()
+                    .map(|scc| { scc.map(|decl| decl.name.0.value) })
+                    .collect::<Vec<_>>(),
+                $want
+                    .into_iter()
+                    .map(|scc| scc.map(String::from))
+                    .collect::<Vec<_>>()
+            )
+        }};
+    }
+
+    use ditto_ast::graph::Scc::*;
+
+    #[test]
+    fn it_toposorts_as_expected() {
+        assert_toposort!(
+            ["a = b", "b = c", "c = []"],
+            [Acyclic("c"), Acyclic("b"), Acyclic("a")]
+        );
+        assert_toposort!(["a = b", "b = a"], [Cyclic(vec!["a", "b"])]);
+        assert_toposort!(["a = a"], [Cyclic(vec!["a"])]);
+        assert_toposort!(
+            ["a = b(a)", "b = fn (x) -> x"],
+            [Acyclic("b"), Cyclic(vec!["a"])]
+        );
+    }
+
+    #[test]
+    fn it_handles_undefined_values() {
+        assert_toposort!(["fine = not(defined)"], [Acyclic("fine")]);
+    }
+}

--- a/crates/ditto-checker/tests/cmd/let_destructure_not_exhaustive_error/test.stderr
+++ b/crates/ditto-checker/tests/cmd/let_destructure_not_exhaustive_error/test.stderr
@@ -1,0 +1,12 @@
+
+  × match not exhaustive
+    ╭─[let_destructure_not_exhaustive_error.ditto:8:1]
+  8 │     let
+  9 │         Some(five) = option_five;
+    ·         ─────┬────
+    ·              ╰── this match expression
+ 10 │     in
+    ╰────
+  help: patterns not covered:
+        None
+

--- a/crates/ditto-checker/tests/cmd/let_destructure_not_exhaustive_error/test.stdin
+++ b/crates/ditto-checker/tests/cmd/let_destructure_not_exhaustive_error/test.stdin
@@ -1,0 +1,11 @@
+module Test exports (..);
+
+type Option(a) = None | Some(a);
+
+option_five = Some(5);
+
+bang = 
+    let
+        Some(five) = option_five;
+    in
+    unit;

--- a/crates/ditto-checker/tests/cmd/let_destructure_not_exhaustive_error/test.toml
+++ b/crates/ditto-checker/tests/cmd/let_destructure_not_exhaustive_error/test.toml
@@ -1,0 +1,4 @@
+bin.name = "ditto-checker-testbin-check-module"
+args = ["let_destructure_not_exhaustive_error.ditto"]
+fs.sandbox = true
+status = "failed"

--- a/crates/ditto-checker/tests/cmd/let_destructuring/test.stdin
+++ b/crates/ditto-checker/tests/cmd/let_destructuring/test.stdin
@@ -1,0 +1,7 @@
+module Test exports (..);
+
+type Wrapper(a) = Wrapped(a);
+
+wrapped_five = Wrapped(5);
+
+fives = let Wrapped(five) = wrapped_five; in [five, five];

--- a/crates/ditto-checker/tests/cmd/let_destructuring/test.stdout
+++ b/crates/ditto-checker/tests/cmd/let_destructuring/test.stdout
@@ -1,0 +1,535 @@
+{
+  "module_name": [
+    "Test"
+  ],
+  "exports": {
+    "types": {
+      "Wrapper": {
+        "Type": {
+          "doc_comments": [],
+          "doc_position": 0,
+          "kind": {
+            "Function": {
+              "parameters": [
+                "Type"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "constructors": {
+      "Wrapped": {
+        "doc_comments": [],
+        "doc_position": 0,
+        "constructor_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "Variable",
+                "data": {
+                  "variable_kind": "Type",
+                  "var": 0,
+                  "source_name": "a"
+                }
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          "Type"
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Test"
+                        ]
+                      ],
+                      "value": "Wrapper"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Wrapper"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": "Type",
+                      "var": 0,
+                      "source_name": "a"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "return_type_name": "Wrapper"
+      }
+    },
+    "values": {
+      "fives": {
+        "doc_comments": [],
+        "doc_position": 0,
+        "value_type": {
+          "type": "Call",
+          "data": {
+            "function": {
+              "type": "PrimConstructor",
+              "data": "Array"
+            },
+            "arguments": [
+              {
+                "type": "PrimConstructor",
+                "data": "Int"
+              }
+            ]
+          }
+        }
+      },
+      "wrapped_five": {
+        "doc_comments": [],
+        "doc_position": 1,
+        "value_type": {
+          "type": "Call",
+          "data": {
+            "function": {
+              "type": "Constructor",
+              "data": {
+                "constructor_kind": {
+                  "Function": {
+                    "parameters": [
+                      "Type"
+                    ]
+                  }
+                },
+                "canonical_value": {
+                  "module_name": [
+                    null,
+                    [
+                      "Test"
+                    ]
+                  ],
+                  "value": "Wrapper"
+                },
+                "source_value": {
+                  "module_name": null,
+                  "value": "Wrapper"
+                }
+              }
+            },
+            "arguments": [
+              {
+                "type": "PrimConstructor",
+                "data": "Int"
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "types": {
+    "Wrapper": {
+      "Type": {
+        "doc_comments": [],
+        "type_name_span": {
+          "start_offset": 32,
+          "end_offset": 39
+        },
+        "kind": {
+          "Function": {
+            "parameters": [
+              "Type"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "constructors": {
+    "Wrapped": {
+      "doc_comments": [],
+      "doc_position": 0,
+      "constructor_name_span": {
+        "start_offset": 45,
+        "end_offset": 52
+      },
+      "fields": [
+        {
+          "type": "Variable",
+          "data": {
+            "variable_kind": "Type",
+            "var": 0,
+            "source_name": "a"
+          }
+        }
+      ],
+      "return_type": {
+        "type": "Call",
+        "data": {
+          "function": {
+            "type": "Constructor",
+            "data": {
+              "constructor_kind": {
+                "Function": {
+                  "parameters": [
+                    "Type"
+                  ]
+                }
+              },
+              "canonical_value": {
+                "module_name": [
+                  null,
+                  [
+                    "Test"
+                  ]
+                ],
+                "value": "Wrapper"
+              },
+              "source_value": {
+                "module_name": null,
+                "value": "Wrapper"
+              }
+            }
+          },
+          "arguments": [
+            {
+              "type": "Variable",
+              "data": {
+                "variable_kind": "Type",
+                "var": 0,
+                "source_name": "a"
+              }
+            }
+          ]
+        }
+      },
+      "return_type_name": "Wrapper"
+    }
+  },
+  "values": {
+    "wrapped_five": {
+      "doc_comments": [],
+      "name_span": {
+        "start_offset": 58,
+        "end_offset": 70
+      },
+      "expression": {
+        "expression": "Call",
+        "data": {
+          "span": {
+            "start_offset": 73,
+            "end_offset": 83
+          },
+          "call_type": {
+            "type": "Call",
+            "data": {
+              "function": {
+                "type": "Constructor",
+                "data": {
+                  "constructor_kind": {
+                    "Function": {
+                      "parameters": [
+                        "Type"
+                      ]
+                    }
+                  },
+                  "canonical_value": {
+                    "module_name": [
+                      null,
+                      [
+                        "Test"
+                      ]
+                    ],
+                    "value": "Wrapper"
+                  },
+                  "source_value": {
+                    "module_name": null,
+                    "value": "Wrapper"
+                  }
+                }
+              },
+              "arguments": [
+                {
+                  "type": "PrimConstructor",
+                  "data": "Int"
+                }
+              ]
+            }
+          },
+          "function": {
+            "expression": "LocalConstructor",
+            "data": {
+              "span": {
+                "start_offset": 73,
+                "end_offset": 80
+              },
+              "constructor_type": {
+                "type": "Function",
+                "data": {
+                  "parameters": [
+                    {
+                      "type": "PrimConstructor",
+                      "data": "Int"
+                    }
+                  ],
+                  "return_type": {
+                    "type": "Call",
+                    "data": {
+                      "function": {
+                        "type": "Constructor",
+                        "data": {
+                          "constructor_kind": {
+                            "Function": {
+                              "parameters": [
+                                "Type"
+                              ]
+                            }
+                          },
+                          "canonical_value": {
+                            "module_name": [
+                              null,
+                              [
+                                "Test"
+                              ]
+                            ],
+                            "value": "Wrapper"
+                          },
+                          "source_value": {
+                            "module_name": null,
+                            "value": "Wrapper"
+                          }
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "type": "PrimConstructor",
+                          "data": "Int"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "constructor": "Wrapped"
+            }
+          },
+          "arguments": [
+            {
+              "Expression": {
+                "expression": "Int",
+                "data": {
+                  "span": {
+                    "start_offset": 81,
+                    "end_offset": 82
+                  },
+                  "value": "5",
+                  "value_type": {
+                    "type": "PrimConstructor",
+                    "data": "Int"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "fives": {
+      "doc_comments": [],
+      "name_span": {
+        "start_offset": 86,
+        "end_offset": 91
+      },
+      "expression": {
+        "expression": "Let",
+        "data": {
+          "span": {
+            "start_offset": 94,
+            "end_offset": 143
+          },
+          "declaration": {
+            "pattern": {
+              "LocalConstructor": {
+                "span": {
+                  "start_offset": 98,
+                  "end_offset": 111
+                },
+                "constructor": "Wrapped",
+                "arguments": [
+                  {
+                    "Variable": {
+                      "span": {
+                        "start_offset": 106,
+                        "end_offset": 110
+                      },
+                      "name": "five"
+                    }
+                  }
+                ]
+              }
+            },
+            "expression_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          "Type"
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Test"
+                        ]
+                      ],
+                      "value": "Wrapper"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Wrapper"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "PrimConstructor",
+                    "data": "Int"
+                  }
+                ]
+              }
+            },
+            "expression": {
+              "expression": "LocalVariable",
+              "data": {
+                "span": {
+                  "start_offset": 114,
+                  "end_offset": 126
+                },
+                "variable_type": {
+                  "type": "Call",
+                  "data": {
+                    "function": {
+                      "type": "Constructor",
+                      "data": {
+                        "constructor_kind": {
+                          "Function": {
+                            "parameters": [
+                              "Type"
+                            ]
+                          }
+                        },
+                        "canonical_value": {
+                          "module_name": [
+                            null,
+                            [
+                              "Test"
+                            ]
+                          ],
+                          "value": "Wrapper"
+                        },
+                        "source_value": {
+                          "module_name": null,
+                          "value": "Wrapper"
+                        }
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "type": "PrimConstructor",
+                        "data": "Int"
+                      }
+                    ]
+                  }
+                },
+                "variable": "wrapped_five"
+              }
+            }
+          },
+          "expression": {
+            "expression": "Array",
+            "data": {
+              "span": {
+                "start_offset": 131,
+                "end_offset": 143
+              },
+              "element_type": {
+                "type": "PrimConstructor",
+                "data": "Int"
+              },
+              "elements": [
+                {
+                  "expression": "LocalVariable",
+                  "data": {
+                    "span": {
+                      "start_offset": 132,
+                      "end_offset": 136
+                    },
+                    "variable_type": {
+                      "type": "PrimConstructor",
+                      "data": "Int"
+                    },
+                    "variable": "five"
+                  }
+                },
+                {
+                  "expression": "LocalVariable",
+                  "data": {
+                    "span": {
+                      "start_offset": 138,
+                      "end_offset": 142
+                    },
+                    "variable_type": {
+                      "type": "PrimConstructor",
+                      "data": "Int"
+                    },
+                    "variable": "five"
+                  }
+                }
+              ],
+              "value_type": {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "PrimConstructor",
+                    "data": "Array"
+                  },
+                  "arguments": [
+                    {
+                      "type": "PrimConstructor",
+                      "data": "Int"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "values_toposort": [
+    "wrapped_five",
+    "fives"
+  ]
+}

--- a/crates/ditto-checker/tests/cmd/let_destructuring/test.toml
+++ b/crates/ditto-checker/tests/cmd/let_destructuring/test.toml
@@ -1,0 +1,3 @@
+bin.name = "ditto-checker-testbin-check-module"
+args = ["let_destructuring.ditto"]
+fs.sandbox = true

--- a/crates/ditto-checker/tests/cmd/let_not_in_scope_error/test.stderr
+++ b/crates/ditto-checker/tests/cmd/let_not_in_scope_error/test.stderr
@@ -1,0 +1,10 @@
+
+  × unknown variable
+   ╭─[let_not_in_scope_error.ditto:4:1]
+ 4 │     let
+ 5 │         fives = [five];
+   ·                  ──┬─
+   ·                    ╰── not in scope
+ 6 │         five: Int = 5;
+   ╰────
+

--- a/crates/ditto-checker/tests/cmd/let_not_in_scope_error/test.stdin
+++ b/crates/ditto-checker/tests/cmd/let_not_in_scope_error/test.stdin
@@ -1,0 +1,8 @@
+module Test exports (..);
+
+bang = 
+    let
+        fives = [five];
+        five: Int = 5;
+    in 
+    fives;

--- a/crates/ditto-checker/tests/cmd/let_not_in_scope_error/test.toml
+++ b/crates/ditto-checker/tests/cmd/let_not_in_scope_error/test.toml
@@ -1,0 +1,4 @@
+bin.name = "ditto-checker-testbin-check-module"
+args = ["let_not_in_scope_error.ditto"]
+fs.sandbox = true
+status = "failed"

--- a/crates/ditto-checker/tests/cmd/let_recursive_error/test.stderr
+++ b/crates/ditto-checker/tests/cmd/let_recursive_error/test.stderr
@@ -1,0 +1,10 @@
+
+  × unknown variable
+   ╭─[let_recursive_error.ditto:4:1]
+ 4 │     let
+ 5 │         a = b;
+   ·             ┬
+   ·             ╰── not in scope
+ 6 │         b = a;
+   ╰────
+

--- a/crates/ditto-checker/tests/cmd/let_recursive_error/test.stdin
+++ b/crates/ditto-checker/tests/cmd/let_recursive_error/test.stdin
@@ -1,0 +1,8 @@
+module Test exports (..);
+
+bang = 
+    let
+        a = b;
+        b = a;
+    in 
+    unit;

--- a/crates/ditto-checker/tests/cmd/let_recursive_error/test.toml
+++ b/crates/ditto-checker/tests/cmd/let_recursive_error/test.toml
@@ -1,0 +1,4 @@
+bin.name = "ditto-checker-testbin-check-module"
+args = ["let_recursive_error.ditto"]
+fs.sandbox = true
+status = "failed"

--- a/crates/ditto-checker/tests/cmd/let_unused_warning/test.stderr
+++ b/crates/ditto-checker/tests/cmd/let_unused_warning/test.stderr
@@ -1,0 +1,9 @@
+
+  ⚠ unused let binder
+   ╭─[let_unused_warning.ditto:2:1]
+ 2 │ 
+ 3 │ why = let fives : Array(Int) = [5]; in unit;
+   ·           ──┬──
+   ·             ╰── this isn't used
+   ╰────
+

--- a/crates/ditto-checker/tests/cmd/let_unused_warning/test.stdin
+++ b/crates/ditto-checker/tests/cmd/let_unused_warning/test.stdin
@@ -1,0 +1,3 @@
+module Test exports (..);
+
+why = let fives : Array(Int) = [5]; in unit;

--- a/crates/ditto-checker/tests/cmd/let_unused_warning/test.stdout
+++ b/crates/ditto-checker/tests/cmd/let_unused_warning/test.stdout
@@ -1,0 +1,125 @@
+{
+  "module_name": [
+    "Test"
+  ],
+  "exports": {
+    "types": {},
+    "constructors": {},
+    "values": {
+      "why": {
+        "doc_comments": [],
+        "doc_position": 0,
+        "value_type": {
+          "type": "PrimConstructor",
+          "data": "Unit"
+        }
+      }
+    }
+  },
+  "types": {},
+  "constructors": {},
+  "values": {
+    "why": {
+      "doc_comments": [],
+      "name_span": {
+        "start_offset": 27,
+        "end_offset": 30
+      },
+      "expression": {
+        "expression": "Let",
+        "data": {
+          "span": {
+            "start_offset": 33,
+            "end_offset": 70
+          },
+          "declaration": {
+            "pattern": {
+              "Variable": {
+                "span": {
+                  "start_offset": 37,
+                  "end_offset": 42
+                },
+                "name": "fives"
+              }
+            },
+            "expression_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "PrimConstructor",
+                  "data": "Array"
+                },
+                "arguments": [
+                  {
+                    "type": "PrimConstructor",
+                    "data": "Int"
+                  }
+                ]
+              }
+            },
+            "expression": {
+              "expression": "Array",
+              "data": {
+                "span": {
+                  "start_offset": 58,
+                  "end_offset": 61
+                },
+                "element_type": {
+                  "type": "PrimConstructor",
+                  "data": "Int"
+                },
+                "elements": [
+                  {
+                    "expression": "Int",
+                    "data": {
+                      "span": {
+                        "start_offset": 59,
+                        "end_offset": 60
+                      },
+                      "value": "5",
+                      "value_type": {
+                        "type": "PrimConstructor",
+                        "data": "Int"
+                      }
+                    }
+                  }
+                ],
+                "value_type": {
+                  "type": "Call",
+                  "data": {
+                    "function": {
+                      "type": "PrimConstructor",
+                      "data": "Array"
+                    },
+                    "arguments": [
+                      {
+                        "type": "PrimConstructor",
+                        "data": "Int"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "expression": {
+            "expression": "Unit",
+            "data": {
+              "span": {
+                "start_offset": 66,
+                "end_offset": 70
+              },
+              "value_type": {
+                "type": "PrimConstructor",
+                "data": "Unit"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "values_toposort": [
+    "why"
+  ]
+}

--- a/crates/ditto-checker/tests/cmd/let_unused_warning/test.toml
+++ b/crates/ditto-checker/tests/cmd/let_unused_warning/test.toml
@@ -1,0 +1,3 @@
+bin.name = "ditto-checker-testbin-check-module"
+args = ["let_unused_warning.ditto"]
+fs.sandbox = true

--- a/crates/ditto-codegen-js/tests/golden/let_expressions.ditto
+++ b/crates/ditto-codegen-js/tests/golden/let_expressions.ditto
@@ -11,3 +11,16 @@ gbp_to_pence = fn (gbp : Gbp): Int -> let Pence(i) = gbp; in i;
 
 type Pair(a, b) = Pair(a, b);
 pair_to_array = fn (pair: Pair(a, a)): Array(a) -> let Pair(fst, snd) = pair; in [fst, snd];
+
+many_lets =
+    -- y tho, maybe we should have a lint for this?
+    let
+        one = 1;
+    in
+    let
+        two = 2;
+    in
+    let
+        three = 3;
+    in
+    [one, two, three];

--- a/crates/ditto-codegen-js/tests/golden/let_expressions.ditto
+++ b/crates/ditto-codegen-js/tests/golden/let_expressions.ditto
@@ -1,0 +1,13 @@
+module Test exports (..);
+
+fives = let five = 5; in [five, five, five];
+
+type alias Ints = Array(Int);
+mk_ints = fn (i: Int): Ints -> let five = 5; six = 6; in [five, six, i, i, i];
+
+type Gbp = Pence(Int);
+
+gbp_to_pence = fn (gbp : Gbp): Int -> let Pence(i) = gbp; in i;
+
+type Pair(a, b) = Pair(a, b);
+pair_to_array = fn (pair: Pair(a, a)): Array(a) -> let Pair(fst, snd) = pair; in [fst, snd];

--- a/crates/ditto-codegen-js/tests/golden/let_expressions.js
+++ b/crates/ditto-codegen-js/tests/golden/let_expressions.js
@@ -4,6 +4,12 @@ function Pair($0, $1) {
 function Pence($0) {
   return ["Pence", $0];
 }
+const many_lets = (() => {
+  const one = 1;
+  const two = 2;
+  const three = 3;
+  return [one, two, three];
+})();
 function pair_to_array(pair) {
   if (pair[0] === "Pair") {
     const snd = pair[2];
@@ -28,4 +34,4 @@ const fives = (() => {
   const five = 5;
   return [five, five, five];
 })();
-export { Pair, Pence, fives, gbp_to_pence, mk_ints, pair_to_array };
+export { Pair, Pence, fives, gbp_to_pence, many_lets, mk_ints, pair_to_array };

--- a/crates/ditto-codegen-js/tests/golden/let_expressions.js
+++ b/crates/ditto-codegen-js/tests/golden/let_expressions.js
@@ -1,0 +1,31 @@
+function Pair($0, $1) {
+  return ["Pair", $0, $1];
+}
+function Pence($0) {
+  return ["Pence", $0];
+}
+function pair_to_array(pair) {
+  if (pair[0] === "Pair") {
+    const snd = pair[2];
+    const fst = pair[1];
+    return [fst, snd];
+  }
+  throw new Error("Pattern match error");
+}
+function gbp_to_pence(gbp) {
+  if (gbp[0] === "Pence") {
+    const i = gbp[1];
+    return i;
+  }
+  throw new Error("Pattern match error");
+}
+function mk_ints(i) {
+  const five = 5;
+  const six = 6;
+  return [five, six, i, i, i];
+}
+const fives = (() => {
+  const five = 5;
+  return [five, five, five];
+})();
+export { Pair, Pence, fives, gbp_to_pence, mk_ints, pair_to_array };

--- a/crates/ditto-cst/src/ditto.lalrpop
+++ b/crates/ditto-cst/src/ditto.lalrpop
@@ -108,6 +108,13 @@ RecordTypeField: cst::RecordTypeField = {
 // EXPRESSIONS
 
 pub Expression: cst::Expression = {
+  Expression4
+}
+
+pub Expression4: cst::Expression = {
+  // let decl0; decl1; in expression
+  <let_keyword: LetKeyword> <head_declaration: Box<LetValueDeclaration>> <tail_declarations: LetValueDeclaration*> <in_keyword: InKeyword> <expr: Box<Expression>> => cst::Expression::Let { let_keyword, head_declaration, tail_declarations, in_keyword, expr },
+
   Expression3
 }
 
@@ -190,10 +197,14 @@ Pattern: cst::Pattern = {
   <unused_name: UnusedName> => cst::Pattern::Unused { unused_name },
 }
 
+pub LetValueDeclaration: cst::LetValueDeclaration = {
+  <pattern: Pattern> <type_annotation: TypeAnnotation?> <equals: Equals> <expression: Expression> <semicolon: Semicolon> => cst::LetValueDeclaration { pattern, type_annotation, equals, expression, semicolon }
+}
+
 Effect: cst::Effect = {
   <return_keyword: ReturnKeyword> <expression: Box<Expression>> => cst::Effect::Return { return_keyword, expression },
   <let_keyword: LetKeyword> <pattern: Pattern> <type_annotation: TypeAnnotation?> <equals: Equals> <expression: Box<Expression>> <semicolon: Semicolon> <rest: Box<Effect>> => cst::Effect::Let { let_keyword, pattern, type_annotation, equals, expression, semicolon, rest },
-  <expression: Box<Expression>> <rest: (Semicolon Box<Effect>)?> => cst::Effect::Expression { expression, rest },
+  <expression: Box<Expression3>> <rest: (Semicolon Box<Effect>)?> => cst::Effect::Expression { expression, rest },
   <name: Name> <left_arrow: LeftArrow> <expression: Box<Expression>> <semicolon: Semicolon> <rest: Box<Effect>> => cst::Effect::Bind { name, left_arrow, expression, semicolon, rest },
 }
 
@@ -301,6 +312,7 @@ ForeignKeyword: cst::ForeignKeyword = { <start_offset: @L> <token: "foreign"> <e
 MatchKeyword: cst::MatchKeyword = { <start_offset: @L> <token: "match"> <end_offset: @R> => cst::MatchKeyword(cst::EmptyToken { span: cst::Span { start_offset, end_offset }, leading_comments: token.leading, trailing_comment: token.trailing, value: () }) }
 WithKeyword: cst::WithKeyword = { <start_offset: @L> <token: "with"> <end_offset: @R> => cst::WithKeyword(cst::EmptyToken { span: cst::Span { start_offset, end_offset }, leading_comments: token.leading, trailing_comment: token.trailing, value: () }) }
 LetKeyword: cst::LetKeyword = { <start_offset: @L> <token: "let"> <end_offset: @R> => cst::LetKeyword(cst::EmptyToken { span: cst::Span { start_offset, end_offset }, leading_comments: token.leading, trailing_comment: token.trailing, value: () }) }
+InKeyword: cst::InKeyword = { <start_offset: @L> <token: "in"> <end_offset: @R> => cst::InKeyword(cst::EmptyToken { span: cst::Span { start_offset, end_offset }, leading_comments: token.leading, trailing_comment: token.trailing, value: () }) }
 DoKeyword: cst::DoKeyword = { <start_offset: @L> <token: "do"> <end_offset: @R> => cst::DoKeyword(cst::EmptyToken { span: cst::Span { start_offset, end_offset }, leading_comments: token.leading, trailing_comment: token.trailing, value: () }) }
 ReturnKeyword: cst::ReturnKeyword = { <start_offset: @L> <token: "return"> <end_offset: @R> => cst::ReturnKeyword(cst::EmptyToken { span: cst::Span { start_offset, end_offset }, leading_comments: token.leading, trailing_comment: token.trailing, value: () }) }
 FnKeyword: cst::FnKeyword = { <start_offset: @L> <token: "fn"> <end_offset: @R> => cst::FnKeyword(cst::EmptyToken { span: cst::Span { start_offset, end_offset }, leading_comments: token.leading, trailing_comment: token.trailing, value: () }) }
@@ -343,6 +355,7 @@ extern {
     "match" => Token::MatchKeyword(<Comments>),
     "with" => Token::WithKeyword(<Comments>),
     "let" => Token::LetKeyword(<Comments>),
+    "in" => Token::InKeyword(<Comments>),
     "do" => Token::DoKeyword(<Comments>),
     "return" => Token::ReturnKeyword(<Comments>),
     "fn" => Token::FnKeyword(<Comments>),

--- a/crates/ditto-cst/src/expression.rs
+++ b/crates/ditto-cst/src/expression.rs
@@ -1,9 +1,9 @@
 use crate::{
     BracesList, BracketsList, CloseBrace, Colon, CommaSep1, DoKeyword, Dot, ElseKeyword,
-    EndKeyword, Equals, FalseKeyword, FnKeyword, IfKeyword, LeftArrow, LetKeyword, MatchKeyword,
-    Name, OpenBrace, Parens, ParensList, ParensList1, Pipe, QualifiedName, QualifiedProperName,
-    ReturnKeyword, RightArrow, RightPizzaOperator, Semicolon, StringToken, ThenKeyword,
-    TrueKeyword, Type, UnitKeyword, UnusedName, WithKeyword,
+    EndKeyword, Equals, FalseKeyword, FnKeyword, IfKeyword, InKeyword, LeftArrow, LetKeyword,
+    MatchKeyword, Name, OpenBrace, Parens, ParensList, ParensList1, Pipe, QualifiedName,
+    QualifiedProperName, ReturnKeyword, RightArrow, RightPizzaOperator, Semicolon, StringToken,
+    ThenKeyword, TrueKeyword, Type, UnitKeyword, UnusedName, WithKeyword,
 };
 
 /// A value expression.
@@ -164,6 +164,19 @@ pub enum Expression {
         /// `}`
         close_brace: CloseBrace,
     },
+    /// `let x : Float = 5.0; y : Float = 10.0; in Float.add(x, y)`
+    Let {
+        /// `let`
+        let_keyword: LetKeyword,
+        /// `x : Float = 5.0`
+        head_declaration: Box<LetValueDeclaration>,
+        /// Any more declarations (there will always be at least one).
+        tail_declarations: Vec<LetValueDeclaration>,
+        /// `in`
+        in_keyword: InKeyword,
+        /// Expression where declaration names are bound.
+        expr: Box<Expression>,
+    },
 }
 
 /// A labelled expression within a record.
@@ -276,6 +289,25 @@ pub enum Pattern {
         /// The unused binder.
         unused_name: UnusedName,
     },
+}
+
+/// Binding an expression to names/patterns.
+///
+/// ```ditto
+/// name : type = expression;
+/// ```
+#[derive(Debug, Clone)]
+pub struct LetValueDeclaration {
+    /// The binding(s)
+    pub pattern: Pattern,
+    /// Optional type of the binding(s).
+    pub type_annotation: Option<TypeAnnotation>,
+    /// `=`
+    pub equals: Equals,
+    /// The value definition itself.
+    pub expression: Expression,
+    /// `;`
+    pub semicolon: Semicolon,
 }
 
 /// `: String`

--- a/crates/ditto-cst/src/get_span.rs
+++ b/crates/ditto-cst/src/get_span.rs
@@ -118,6 +118,9 @@ impl Expression {
                 close_brace,
                 ..
             } => open_brace.0.get_span().merge(&close_brace.0.get_span()),
+            Self::Let {
+                let_keyword, expr, ..
+            } => let_keyword.0.get_span().merge(&expr.get_span()),
         }
     }
 }

--- a/crates/ditto-cst/src/lexer.rs
+++ b/crates/ditto-cst/src/lexer.rs
@@ -102,6 +102,7 @@ impl<'input> Iterator for Lexer<'input> {
             RawToken::MatchKeyword => Token::MatchKeyword(self.collect_comments()),
             RawToken::WithKeyword => Token::WithKeyword(self.collect_comments()),
             RawToken::LetKeyword => Token::LetKeyword(self.collect_comments()),
+            RawToken::InKeyword => Token::InKeyword(self.collect_comments()),
             RawToken::DoKeyword => Token::DoKeyword(self.collect_comments()),
             RawToken::ReturnKeyword => Token::ReturnKeyword(self.collect_comments()),
             RawToken::FnKeyword => Token::FnKeyword(self.collect_comments()),
@@ -161,6 +162,7 @@ pub enum Token {
     MatchKeyword(Comments),
     WithKeyword(Comments),
     LetKeyword(Comments),
+    InKeyword(Comments),
     DoKeyword(Comments),
     ReturnKeyword(Comments),
     FnKeyword(Comments),
@@ -244,6 +246,8 @@ enum RawToken {
     WithKeyword,
     #[token("let")]
     LetKeyword,
+    #[token("in")]
+    InKeyword,
     #[token("do")]
     DoKeyword,
     #[token("return")]

--- a/crates/ditto-cst/src/parser/tests/expression.rs
+++ b/crates/ditto-cst/src/parser/tests/expression.rs
@@ -562,3 +562,13 @@ fn it_parses_record_updates() {
         Expression::RecordUpdate { .. }
     );
 }
+
+#[test]
+fn it_parses_let_expressions() {
+    assert_parses!("let five = 5; in five", Expression::Let { .. });
+    assert_parses!(
+        "let five = 5; ten: Int = 10; in add(five, ten)",
+        Expression::Let { .. }
+    );
+    assert_parses!("let Wrapped(x) = wrapped; in x", Expression::Let { .. });
+}

--- a/crates/ditto-cst/src/token.rs
+++ b/crates/ditto-cst/src/token.rs
@@ -200,6 +200,10 @@ pub struct WithKeyword(pub EmptyToken);
 #[derive(Debug, Clone)]
 pub struct LetKeyword(pub EmptyToken);
 
+/// `in`
+#[derive(Debug, Clone)]
+pub struct InKeyword(pub EmptyToken);
+
 /// `do`
 #[derive(Debug, Clone)]
 pub struct DoKeyword(pub EmptyToken);

--- a/crates/ditto-fmt/src/has_comments.rs
+++ b/crates/ditto-fmt/src/has_comments.rs
@@ -109,6 +109,19 @@ impl HasComments for Expression {
                     || updates.has_comments()
                     || close_brace.0.has_comments()
             }
+            Self::Let {
+                let_keyword,
+                head_declaration,
+                tail_declarations,
+                in_keyword,
+                expr,
+            } => {
+                let_keyword.0.has_comments()
+                    || head_declaration.has_comments()
+                    || tail_declarations.iter().any(|decl| decl.has_comments())
+                    || in_keyword.0.has_comments()
+                    || expr.has_comments()
+            }
         }
     }
 
@@ -133,6 +146,7 @@ impl HasComments for Expression {
             Self::RecordAccess { target, .. } => target.has_leading_comments(),
             Self::Record(braces) => braces.open_brace.0.has_leading_comments(),
             Self::RecordUpdate { open_brace, .. } => open_brace.0.has_leading_comments(),
+            Self::Let { let_keyword, .. } => let_keyword.0.has_leading_comments(),
         }
     }
 }
@@ -451,6 +465,27 @@ impl HasComments for Export {
             Self::Value(name) => name.has_leading_comments(),
             Self::Type(proper_name, _everything) => proper_name.has_leading_comments(),
         }
+    }
+}
+
+impl HasComments for LetValueDeclaration {
+    fn has_comments(&self) -> bool {
+        let LetValueDeclaration {
+            pattern,
+            type_annotation,
+            equals,
+            expression,
+            semicolon,
+        } = self;
+        pattern.has_comments()
+            || type_annotation.has_comments()
+            || equals.0.has_comments()
+            || expression.has_comments()
+            || semicolon.0.has_comments()
+    }
+    fn has_leading_comments(&self) -> bool {
+        let LetValueDeclaration { pattern, .. } = self;
+        pattern.has_leading_comments()
     }
 }
 

--- a/crates/ditto-fmt/src/token.rs
+++ b/crates/ditto-fmt/src/token.rs
@@ -43,6 +43,7 @@ gen_empty_token_like!(gen_foreign_keyword, cst::ForeignKeyword, "foreign");
 gen_empty_token_like!(gen_fn_keyword, cst::FnKeyword, "fn");
 gen_empty_token_like!(gen_end_keyword, cst::EndKeyword, "end");
 gen_empty_token_like!(gen_let_keyword, cst::LetKeyword, "let");
+gen_empty_token_like!(gen_in_keyword, cst::InKeyword, "in");
 gen_empty_token_like!(gen_open_bracket, cst::OpenBracket, "[");
 gen_empty_token_like!(gen_open_brace, cst::OpenBrace, "{");
 gen_empty_token_like!(gen_pipe, cst::Pipe, "|");

--- a/crates/ditto-fmt/tests/golden/let_expressions.ditto
+++ b/crates/ditto-fmt/tests/golden/let_expressions.ditto
@@ -37,3 +37,16 @@ funky_fives = [
     five,
     5,
 ];
+
+many_lets =
+    -- y tho - maybe we should have a lint for this?
+    let
+        one = 1;
+    in
+    let
+        two = 2;
+    in
+    let
+        three = 3;
+    in
+    [one, two, three];

--- a/crates/ditto-fmt/tests/golden/let_expressions.ditto
+++ b/crates/ditto-fmt/tests/golden/let_expressions.ditto
@@ -1,0 +1,39 @@
+module Let exports (..);
+
+
+fives =
+    let
+        five = 5;  -- comment
+    in
+    [five, five, five];
+
+mk_ints = fn (i: Int) ->
+    let
+        -- comment
+        five = 5;  -- comment
+
+        -- comment
+        six = 6;
+
+        ints = [
+            -- comment
+            five,
+            six,
+            i,  -- comment
+            i,
+            i,
+        ];
+    in
+    -- comment
+    {
+        -- comment
+        ints = [ints],
+    };
+
+funky_fives = [
+    let
+        five = 5;
+    in
+    five,
+    5,
+];

--- a/crates/ditto-lsp/src/semantic_tokens.rs
+++ b/crates/ditto-lsp/src/semantic_tokens.rs
@@ -119,6 +119,8 @@ impl TokensBuilder {
               "do"
               "return"
               "alias"
+              "let"
+              "in"
             ] @keyword
 
             ; 2, 3, 4

--- a/crates/ditto-tree-sitter/Cargo.toml
+++ b/crates/ditto-tree-sitter/Cargo.toml
@@ -9,7 +9,7 @@ doctest = false
 
 [dependencies]
 tree-sitter = "0.20"
-tree-sitter-ditto = { git = "https://github.com/ditto-lang/tree-sitter-ditto", rev = "d2a30bc3aab2a4c4502e8b6d192aa648bacd84a4" }
+tree-sitter-ditto = { git = "https://github.com/ditto-lang/tree-sitter-ditto", rev = "06f09cc4a923fa656381949a0952df863bbc3170" }
 
 [dev-dependencies]
 datatest-stable = "0.1"


### PR DESCRIPTION
Adds `let` expressions of the form:

```ditto
let
	x = 5;
    y = [x, x, x];
    Ctor(z) = some_ctor;  -- pattern binders are supported
in
do_something_with_bindings(x, y, z)
```

In the original [issue](#10) I said:

> let bindings should behave exactly like top-level value declarations - **they should be recursive and order independent**.

But with this PR they aren't recursive or order independent, my reasons being:

1. Topologically sorting the declarations with [pattern binders](#59), which isn't allowed for top-level declarations atm, is _tricky_ and not something I want to deal with right now.
2. I'm not 100% sure what support is like for _local_ recursive assignments across the languages I'd eventually like to target (e.g. erlang)
3. This is an acceptable implementation to being with. And recursiveness/toposorting can probably be added later without breaking syntax changes (unless there's a need for a `rec` keyword...)