### PR TITLE
Type annotate empty arrays (with JSDoc)

### DIFF
--- a/crates/ditto-codegen-js/src/render.rs
+++ b/crates/ditto-codegen-js/src/render.rs
@@ -190,6 +190,9 @@ impl Render for Expression {
                 accum.push(':');
                 false_clause.render(accum);
             }
+            Self::Array(expressions) if expressions.is_empty() => {
+                accum.push_str("/** @type {readonly any[]} */([])");
+            }
             Self::Array(expressions) => {
                 accum.push('[');
                 render_comma_sep(expressions, accum);

--- a/crates/ditto-codegen-js/tests/golden/basic_expressions.ditto
+++ b/crates/ditto-codegen-js/tests/golden/basic_expressions.ditto
@@ -21,6 +21,8 @@ select = fn (c, x, y) -> if c then x else y;
 -- REVIEW `return undefined` is redundant
 denied = fn (a) -> unit;
 
+empty_array = [];
+
 fives = [
   5,
   five,

--- a/crates/ditto-codegen-js/tests/golden/basic_expressions.js
+++ b/crates/ditto-codegen-js/tests/golden/basic_expressions.js
@@ -1,3 +1,4 @@
+const empty_array = /** @type {readonly any[]} */ [];
 function denied(a) {
   return;
 }

--- a/crates/ditto-codegen-js/tests/golden/objects.js
+++ b/crates/ditto-codegen-js/tests/golden/objects.js
@@ -17,7 +17,9 @@ const foo = mk_has_foo(true)["foo"];
 function get_foo(x) {
   return x["foo"];
 }
-const very_nested = { a: { b: { c: { d: [] } } } };
+const very_nested = {
+  a: { b: { c: { d: /** @type {readonly any[]} */ [] } } },
+};
 const d = very_nested["a"]["b"]["c"]["d"];
 const just_object_things = { yep: true, huh: undefined, why: () => ({}) };
 const empty_object = {};


### PR DESCRIPTION
Under some circumstances TypeScript will infer `[]` as type `never[]`, which was causing problems for me trying to type-check some generated (package) code.

Generating code that is "correct" as far as `tsc` is concerned is important to me, so I think this change is reasonable. 

Note that the empty array _needs_ to be in parentheses for the `@type` comment to apply. Which means `prettier` can break this 😬 

[See this Stack Overflow answer](https://stackoverflow.com/a/70101585)