### PR TITLE
Add support for github packages :octocat: 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +173,15 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -412,6 +432,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +566,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "dirs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +661,7 @@ version = "0.0.1"
 dependencies = [
  "assert_cmd",
  "assert_fs",
+ "async-recursion",
  "atty",
  "chrono",
  "clap 4.0.26",
@@ -650,6 +689,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha256",
  "shlex",
  "similar-asserts",
  "symlink",
@@ -1049,6 +1089,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,6 +1204,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1733,6 +1789,12 @@ name = "once_cell"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -2359,6 +2421,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha256"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e334db67871c14c18fc066ad14af13f9fdf5f9a91c61af432d1e3a39c8c6a141"
+dependencies = [
+ "hex",
+ "sha2",
+]
+
+[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2847,6 +2932,12 @@ dependencies = [
  "snapbox",
  "toml_edit",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"

--- a/crates/ditto-cli/Cargo.toml
+++ b/crates/ditto-cli/Cargo.toml
@@ -45,6 +45,8 @@ atty = "0.2"
 semver = "1.0"
 shlex = "1.1"
 crossbeam-channel = "0.5"
+sha256 = "1.1"
+async-recursion = "1.0"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/crates/ditto-cli/src/pkg.rs
+++ b/crates/ditto-cli/src/pkg.rs
@@ -1,9 +1,12 @@
 // Maybe this should live in it's own crate?
-use crate::{common::is_plain, spinner::Spinner};
+use crate::{
+    common::{get_ditto_cache_dir, is_plain},
+    spinner::Spinner,
+};
 use console::{Emoji, Style};
 use ditto_config::{
-    read_config, Config, Dependencies, PackageName, PackageSetPackages as Packages, PackageSpec,
-    CONFIG_FILE_NAME,
+    read_config, Config, Dependencies, GithubPackageSpec, PackageName,
+    PackageSetPackages as Packages, PackageSpec, CONFIG_FILE_NAME,
 };
 use indicatif::MultiProgress;
 use log::{debug, warn};
@@ -77,7 +80,8 @@ pub async fn check_packages_up_to_date(
         &mut Dependencies::new(),
         &installed_packages,
         &available_packages,
-    )?;
+    )
+    .await?;
 
     debug!(
         "Updating {} with {}",
@@ -106,8 +110,8 @@ fn hash_packages_inputs(dependencies: &Dependencies, packages: &Packages) -> u64
     hasher.finish()
 }
 
-// TODO make this async
-fn update_dependencies(
+#[async_recursion::async_recursion]
+async fn update_dependencies(
     _multi_progress: &mut MultiProgress,
     packages_dir: &Path,
     dependencies: &Dependencies,
@@ -132,7 +136,7 @@ fn update_dependencies(
                     debug!("Removing existing install of {}", dependency.as_str());
                     spinner.set_message("removing existing install");
                     remove_package(packages_dir, dependency)?;
-                    install_package(spinner, packages_dir, dependency, available_spec)?;
+                    install_package(spinner, packages_dir, dependency, available_spec).await?;
                 }
                 updated_dependencies.insert(dependency.clone());
                 let config = read_package_config(packages_dir, dependency)?;
@@ -143,7 +147,8 @@ fn update_dependencies(
                     updated_dependencies,
                     installed_packages,
                     available_packages,
-                )?
+                )
+                .await?
             }
             (None, Some(available_spec)) => {
                 // Not installed
@@ -151,7 +156,7 @@ fn update_dependencies(
                 //let mut progress = multi_progress.add(ProgressBar::new_spinner());
                 let spinner = Spinner::new_with_prefix(dependency.as_str().to_string());
 
-                install_package(spinner, packages_dir, dependency, available_spec)?;
+                install_package(spinner, packages_dir, dependency, available_spec).await?;
                 updated_dependencies.insert(dependency.clone());
                 let config = read_package_config(packages_dir, dependency)?;
                 update_dependencies(
@@ -161,7 +166,8 @@ fn update_dependencies(
                     updated_dependencies,
                     installed_packages,
                     available_packages,
-                )?
+                )
+                .await?
             }
             (Some(_installed_spec), None) => {
                 return Err(miette!(
@@ -179,47 +185,185 @@ fn update_dependencies(
 
 const EXTENSION_SPEC: &str = "spec";
 
-fn install_package(
-    mut spinner: Spinner,
+async fn install_package(
+    spinner: Spinner,
     packages_dir: &Path,
     package_name: &str,
     spec: &PackageSpec,
 ) -> Result<()> {
-    debug!("Installing {:?}", package_name);
+    debug!("installing {:?}", package_name);
     match spec {
-        PackageSpec::Path { path: src } => {
-            let mut dst = packages_dir.to_path_buf();
-            let src = pathdiff::diff_paths(src, packages_dir).unwrap();
-            dst.push(package_name);
-
-            debug!(
-                "linking {} -> {}",
-                dst.to_string_lossy(),
-                src.to_string_lossy(),
-            );
-            spinner.set_message(format!(
-                "{} -> {}",
-                dst.to_string_lossy(),
-                src.to_string_lossy(),
-            ));
-            symlink::symlink_dir(src, dst).into_diagnostic()?;
-
-            let mut spec_path = packages_dir.to_path_buf();
-            spec_path.push(package_name);
-            spec_path.set_extension(EXTENSION_SPEC);
-            let spec_file = fs::File::create(&spec_path).into_diagnostic()?;
-            serde_json::to_writer(spec_file, spec).into_diagnostic()?;
-
-            debug!(
-                "{:?} spec written to {}",
+        PackageSpec::Path { path } => {
+            install_package_from_path(spinner, packages_dir, package_name, path)?;
+        }
+        PackageSpec::Github {
+            github,
+            revision,
+            sha256,
+        } => {
+            install_package_from_github(
+                spinner,
+                packages_dir,
                 package_name,
-                spec_path.to_string_lossy()
-            );
-
-            spinner.success("installed")
+                github,
+                revision,
+                sha256,
+            )
+            .await?;
         }
     }
+
+    let mut spec_path = packages_dir.to_path_buf();
+    spec_path.push(package_name);
+    spec_path.set_extension(EXTENSION_SPEC);
+    let spec_file = fs::File::create(&spec_path).into_diagnostic()?;
+    serde_json::to_writer(spec_file, spec).into_diagnostic()?;
+
+    debug!(
+        "{:?} spec written to {}",
+        package_name,
+        spec_path.to_string_lossy()
+    );
+
     Ok(())
+}
+
+fn install_package_from_path(
+    mut spinner: Spinner,
+    packages_dir: &Path,
+    package_name: &str,
+    path: &Path,
+) -> Result<()> {
+    let src = pathdiff::diff_paths(path, packages_dir).unwrap();
+    let mut dst = packages_dir.to_path_buf();
+    dst.push(package_name);
+
+    debug!(
+        "linking {} -> {}",
+        dst.to_string_lossy(),
+        src.to_string_lossy(),
+    );
+    spinner.set_message(format!(
+        "{} -> {}",
+        dst.to_string_lossy(),
+        src.to_string_lossy(),
+    ));
+    symlink::symlink_dir(src, dst).into_diagnostic()?;
+
+    spinner.success("installed");
+
+    Ok(())
+}
+
+async fn install_package_from_github(
+    mut spinner: Spinner,
+    packages_dir: &Path,
+    package_name: &str,
+    github: &GithubPackageSpec,
+    revision: &str,
+    sha256: &str,
+) -> Result<()> {
+    let mut zip_archive =
+        fetch_cached_github_archive(&mut spinner, github, revision, sha256).await?;
+
+    let mut dst = packages_dir.to_path_buf();
+    dst.push(package_name);
+
+    for name in zip_archive
+        .file_names()
+        .map(|str| str.to_string())
+        .collect::<Vec<_>>()
+    {
+        let mut zip_file = zip_archive.by_name(&name).into_diagnostic()?;
+        if zip_file.is_dir() {
+            continue;
+        }
+        let zip_path = zip_file
+            .enclosed_name()
+            .ok_or_else(|| miette!("encountered bad zip file path!"))?;
+        let mut dst = dst.clone();
+        dst.extend(
+            // drop the root directory from the zip file
+            zip_path.components().skip(1),
+        );
+
+        if let Some(parent) = dst.parent() {
+            if !parent.exists() {
+                fs::create_dir_all(parent).into_diagnostic()?;
+            }
+        }
+        debug!("{:?} -> {:?}", zip_path, &dst);
+        let mut file = std::fs::File::create(dst).into_diagnostic()?;
+        std::io::copy(&mut zip_file, &mut file).into_diagnostic()?;
+    }
+
+    spinner.success("installed");
+    Ok(())
+}
+
+async fn fetch_cached_github_archive(
+    spinner: &mut Spinner,
+    github: &GithubPackageSpec,
+    revision: &str,
+    sha256: &str,
+) -> Result<zip::ZipArchive<std::fs::File>> {
+    // Is it in the cache?
+    let mut cached_zip = get_github_cache_dir()?;
+    cached_zip.push(sha256);
+    cached_zip.set_extension("zip");
+    if cached_zip.exists() {
+        let file = std::fs::File::open(&cached_zip).into_diagnostic()?;
+        let zip_archive = zip::ZipArchive::new(file).into_diagnostic()?;
+        return Ok(zip_archive);
+    }
+
+    // Nope, download it...
+    let archive_url = format!(
+        "https://github.com/{owner}/{repo}/archive/{revision}.zip",
+        owner = github.owner,
+        repo = github.repo,
+    );
+    debug!("GET {}", archive_url);
+    spinner.set_message(format!("Downloading {}", archive_url));
+    let response = reqwest::get(&archive_url).await.into_diagnostic()?;
+    if !response.status().is_success() {
+        return Err(miette!("{} {}", response.status(), archive_url));
+    }
+    let content = response.bytes().await.into_diagnostic()?;
+    let got_sha256 = sha256::digest(content.as_ref());
+    if got_sha256 != sha256 {
+        return Err(miette!(
+            "sha256 mismatch for {}/{}, expected {:?} but got {:?}",
+            github.owner,
+            github.repo,
+            sha256,
+            got_sha256
+        ));
+    }
+    debug!("Writing archive to {:?}", cached_zip);
+    std::fs::write(&cached_zip, content).into_diagnostic()?;
+    let file = std::fs::File::open(&cached_zip).into_diagnostic()?;
+    let zip_archive = zip::ZipArchive::new(file).into_diagnostic()?;
+    Ok(zip_archive)
+}
+
+pub fn get_github_cache_dir() -> Result<PathBuf> {
+    let mut cache_dir = get_ditto_cache_dir()?;
+    cache_dir.push("github");
+    if !cache_dir.exists() {
+        debug!(
+            "Github cache directory doesn't exist, creating {:?}",
+            cache_dir
+        );
+        std::fs::create_dir_all(&cache_dir)
+            .into_diagnostic()
+            .wrap_err(format!(
+                "error initializing github cache dir at {:?}",
+                cache_dir
+            ))?;
+    }
+
+    Ok(cache_dir)
 }
 
 fn remove_package(packages_dir: &Path, package_name: &str) -> Result<()> {

--- a/crates/ditto-config/src/package_set.rs
+++ b/crates/ditto-config/src/package_set.rs
@@ -73,5 +73,22 @@ pub enum PackageSpec {
         /// Path to the local package.
         path: PathBuf,
     },
-    // TODO Url
+    /// A GitHub repo.
+    Github {
+        /// The owner and repo names.
+        github: GithubPackageSpec,
+        /// The revision to use.
+        revision: String,
+        /// The hash of the repo zip.
+        sha256: String,
+    },
+}
+
+/// Description of a Github repository.
+#[derive(Clone, Hash, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct GithubPackageSpec {
+    /// The user or organisation name.
+    pub owner: String,
+    /// The repository name.
+    pub repo: String,
 }

--- a/crates/ditto-config/src/tests.rs
+++ b/crates/ditto-config/src/tests.rs
@@ -86,6 +86,11 @@ mod successes {
 
             [package-set.packages] 
             foo = { path = "../test" }
+
+            [package-set.packages.bar]
+            github = { owner = "some-owner", repo = "some-repo"}
+            revision = "some-rev"
+            sha256 = "some-digest"
         "#
         );
     }


### PR DESCRIPTION
Extends the `PackageSpec` type to support GitHub repositories and updates the install logic.

A GitHub package dependency is specified like:

```toml
[package-set.packages.js-ref]
github = { owner = "ditto-lang", repo = "js-ref" }     # inspired by Nix's fetchFromGitHub
revision = "fb8a458da5a9394afc199974ed880bf9e99c7571"
sha256 = "a25b7f0f65ce48157ca6ff536b675c7fdd1383c6b901991257328bbd6189cf3d"
```

The install logic is then:

1. `GET https://github.com/{github.owner}/{github.repo}/archive/{revision}.zip`
2. Check that the sha256 matches
3. Store the downloaded zip archive in the cache, using the sha256 as the key (much like [Nix](https://nixos.org/))
4. Unpack contents of the archive into the current project's package directory

And if the entry already exists in the cache, we skip straight to **4**.