### PR TITLE
Fix unused JavaScript identifiers :wrench: 

### DIFF
--- a/crates/ditto-codegen-js/src/optimize/mod.rs
+++ b/crates/ditto-codegen-js/src/optimize/mod.rs
@@ -660,8 +660,12 @@ mod test {
 
     #[test]
     fn roundtrippin() {
-        assert_optimized!("fn (x, _y) -> x", "(x,_y) => x", &[]);
-        assert_optimized!("fn (x, _y) -> if x then 5 else 10", "(x,_y) => x?5:10", &[]);
+        assert_optimized!("fn (x, _y) -> x", "(x,_y$0) => x", &[]);
+        assert_optimized!(
+            "fn (x, _y) -> if x then 5 else 10",
+            "(x,_y$0) => x?5:10",
+            &[]
+        );
         assert_optimized!(
             "fn (x, y) -> if x then 5 else if y then 10 else 15",
             "(x,y) => x?5:y?10:15",

--- a/crates/ditto-codegen-js/tests/golden/basic_expressions.js
+++ b/crates/ditto-codegen-js/tests/golden/basic_expressions.js
@@ -6,7 +6,7 @@ function select(c, x, y) {
   return c ? x : y;
 }
 function always(a) {
-  return _b => a;
+  return _b$0 => a;
 }
 function uncurry(f) {
   return (a, b) => f(a)(b);
@@ -27,7 +27,7 @@ const fives = [
   select(true, 5, 50),
   always(five)(floaty_five),
   uncurry(always)(five, true),
-  ((a, _b) => a)(5, undefined),
+  ((a, _b$0) => a)(5, undefined),
   uncurry(always)(five, fifth_string),
   always(identity)(false)(five),
 ];

--- a/crates/ditto-codegen-js/tests/golden/effect_expressions.js
+++ b/crates/ditto-codegen-js/tests/golden/effect_expressions.js
@@ -28,7 +28,7 @@ function get_five() {
   }
   throw new Error("Pattern match error");
 }
-function always(_a, b) {
+function always(_a$0, b) {
   return b;
 }
 function effect_map(effect_a, f) {

--- a/crates/ditto-codegen-js/tests/golden/unused_patterns.ditto
+++ b/crates/ditto-codegen-js/tests/golden/unused_patterns.ditto
@@ -1,0 +1,4 @@
+module Test exports (..);
+
+
+always_five = fn (_, _, _) -> 5;

--- a/crates/ditto-codegen-js/tests/golden/unused_patterns.js
+++ b/crates/ditto-codegen-js/tests/golden/unused_patterns.js
@@ -1,0 +1,4 @@
+function always_five(_$0, _$1, _$2) {
+  return 5;
+}
+export { always_five };


### PR DESCRIPTION
The following is legal ditto code:

```ditto
ignore_both_args = fn (_, _) -> 5;
```

But currently that will generate the following JavaScript:

```js
function ignore_both_args(_, _) {
  return 5;
}
```

Which will raise an error to the effect of: `SyntaxError: Duplicate parameter name not allowed in this context`.

Hence, we need to ensure that unused identifiers are unique.