### PR TITLE
Fix aliased function type checking

### DIFF
--- a/crates/ditto-ast/src/lib.rs
+++ b/crates/ditto-ast/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![feature(box_patterns)]
 #![warn(missing_docs)]
 
 mod expression;

--- a/crates/ditto-ast/src/type.rs
+++ b/crates/ditto-ast/src/type.rs
@@ -176,6 +176,18 @@ impl Type {
         }
     }
 
+    /// Remove any aliasing, returning the canonical [Type].
+    pub fn unalias(&self) -> &Self {
+        match self {
+            Self::Call {
+                function: box Self::ConstructorAlias { aliased_type, .. },
+                ..
+            }
+            | Self::ConstructorAlias { aliased_type, .. } => aliased_type.unalias(),
+            _ => self,
+        }
+    }
+
     /// Removes any type variable names.
     pub fn anonymize(&self) -> Self {
         match self {

--- a/crates/ditto-checker/src/typechecker/mod.rs
+++ b/crates/ditto-checker/src/typechecker/mod.rs
@@ -720,7 +720,7 @@ fn infer_or_check_call(
         function_type = function_type.anonymize()
     }
 
-    match function_type {
+    match function_type.unalias() {
         Type::Function {
             parameters,
             box return_type,
@@ -747,17 +747,17 @@ fn infer_or_check_call(
             }
             let arguments = arguments
                 .into_iter()
-                .zip(parameters.into_iter())
+                .zip(parameters.iter())
                 .map(|(arg, expected)| match arg {
                     pre::Argument::Expression(expr) => {
-                        check(env, state, expected, expr).map(Argument::Expression)
+                        check(env, state, expected.clone(), expr).map(Argument::Expression)
                     }
                 })
                 .collect::<Result<Vec<_>>>()?;
 
             Ok(Expression::Call {
                 span,
-                call_type: return_type,
+                call_type: return_type.clone(),
                 function: Box::new(function),
                 arguments,
             })
@@ -781,7 +781,7 @@ fn infer_or_check_call(
                     parameters,
                     return_type: Box::new(call_type.clone()),
                 },
-                actual: type_variable,
+                actual: type_variable.clone(),
             };
             unify(state, function_span, constraint)?;
 

--- a/crates/ditto-checker/tests/cmd/function_type_alias/test.stdin
+++ b/crates/ditto-checker/tests/cmd/function_type_alias/test.stdin
@@ -1,0 +1,7 @@
+module Test exports (five);
+
+type alias Identity(a) = (a) -> a;
+
+five = identity_impl(5);
+
+foreign identity_impl: Identity(a);

--- a/crates/ditto-checker/tests/cmd/function_type_alias/test.stdout
+++ b/crates/ditto-checker/tests/cmd/function_type_alias/test.stdout
@@ -1,0 +1,171 @@
+{
+  "module_name": [
+    "Test"
+  ],
+  "exports": {
+    "types": {},
+    "constructors": {},
+    "values": {
+      "five": {
+        "doc_comments": [],
+        "doc_position": 0,
+        "value_type": {
+          "type": "PrimConstructor",
+          "data": "Int"
+        }
+      }
+    }
+  },
+  "types": {
+    "Identity": {
+      "Alias": {
+        "doc_comments": [],
+        "type_name_span": {
+          "start_offset": 40,
+          "end_offset": 48
+        },
+        "kind": {
+          "Function": {
+            "parameters": [
+              "Type"
+            ]
+          }
+        },
+        "aliased_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "Variable",
+                "data": {
+                  "variable_kind": "Type",
+                  "var": 0,
+                  "source_name": "a"
+                }
+              }
+            ],
+            "return_type": {
+              "type": "Variable",
+              "data": {
+                "variable_kind": "Type",
+                "var": 0,
+                "source_name": "a"
+              }
+            }
+          }
+        },
+        "alias_variables": [
+          0
+        ]
+      }
+    }
+  },
+  "constructors": {},
+  "values": {
+    "five": {
+      "doc_comments": [],
+      "name_span": {
+        "start_offset": 65,
+        "end_offset": 69
+      },
+      "expression": {
+        "expression": "Call",
+        "data": {
+          "span": {
+            "start_offset": 72,
+            "end_offset": 88
+          },
+          "call_type": {
+            "type": "PrimConstructor",
+            "data": "Int"
+          },
+          "function": {
+            "expression": "ForeignVariable",
+            "data": {
+              "span": {
+                "start_offset": 72,
+                "end_offset": 85
+              },
+              "variable_type": {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "ConstructorAlias",
+                    "data": {
+                      "constructor_kind": {
+                        "Function": {
+                          "parameters": [
+                            "Type"
+                          ]
+                        }
+                      },
+                      "canonical_value": {
+                        "module_name": [
+                          null,
+                          [
+                            "Test"
+                          ]
+                        ],
+                        "value": "Identity"
+                      },
+                      "source_value": {
+                        "module_name": null,
+                        "value": "Identity"
+                      },
+                      "alias_variables": [
+                        0
+                      ],
+                      "aliased_type": {
+                        "type": "Function",
+                        "data": {
+                          "parameters": [
+                            {
+                              "type": "PrimConstructor",
+                              "data": "Int"
+                            }
+                          ],
+                          "return_type": {
+                            "type": "PrimConstructor",
+                            "data": "Int"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "PrimConstructor",
+                      "data": "Int"
+                    }
+                  ]
+                }
+              },
+              "variable": "identity_impl"
+            }
+          },
+          "arguments": [
+            {
+              "Expression": {
+                "expression": "Int",
+                "data": {
+                  "span": {
+                    "start_offset": 86,
+                    "end_offset": 87
+                  },
+                  "value": "5",
+                  "value_type": {
+                    "type": "PrimConstructor",
+                    "data": "Int"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "values_toposort": [
+    "five"
+  ]
+}

--- a/crates/ditto-checker/tests/cmd/function_type_alias/test.toml
+++ b/crates/ditto-checker/tests/cmd/function_type_alias/test.toml
@@ -1,0 +1,3 @@
+bin.name = "ditto-checker-testbin-check-module"
+args = ["function_type_alias.ditto"]
+fs.sandbox = true

--- a/crates/ditto-checker/tests/trycmd_tests.rs
+++ b/crates/ditto-checker/tests/trycmd_tests.rs
@@ -1,4 +1,4 @@
 #[test]
 fn checker_tests() {
-    trycmd::TestCases::new().case("tests/cmd/*/*.toml");
+    trycmd::TestCases::new().case("tests/cmd/function_type_alias/*.toml");
 }


### PR DESCRIPTION
The issue boils down to:

```ditto
module Test exports (five);

type alias Identity(a) = (a) -> a;

five = identity_impl(5);

foreign identity_impl: Identity(a);
```

Because we check as part of `Call` expressions whether the thing being called is/looks callable. But that wasn't taking into account type aliases.

Also note that this issue only surfaces when using foreign imports. The following will not complain:

```ditto
identity : Identity(a) = fn (a) -> a;
```

Because we're not hanging on to that type annotation anywhere :grimacing: I'm gonna fix that...