### PR TITLE
Store any type annotations in the AST

### DIFF
--- a/crates/ditto-checker/src/typechecker/substitution.rs
+++ b/crates/ditto-checker/src/typechecker/substitution.rs
@@ -224,10 +224,12 @@ impl Substitution {
             },
             Function {
                 span,
+                function_type,
                 binders,
                 box body,
             } => Function {
                 span,
+                function_type: self.apply(function_type),
                 binders: binders
                     .into_iter()
                     .map(|(pattern, t)| (pattern, self.apply(t)))
@@ -266,10 +268,12 @@ impl Substitution {
             },
             Effect {
                 span,
+                effect_type,
                 return_type,
                 effect,
             } => Effect {
                 span,
+                effect_type: self.apply(effect_type),
                 return_type: self.apply(return_type),
                 effect: self.apply_effect(effect),
             },
@@ -332,8 +336,13 @@ impl Substitution {
                     .collect(),
                 value_type: self.apply(value_type),
             },
-            Record { span, fields } => Record {
+            Record {
                 span,
+                record_type,
+                fields,
+            } => Record {
+                span,
+                record_type: self.apply(record_type),
                 fields: fields
                     .into_iter()
                     .map(|(label, expr)| (label, self.apply_expression(expr)))

--- a/crates/ditto-checker/src/typechecker/tests/records.rs
+++ b/crates/ditto-checker/src/typechecker/tests/records.rs
@@ -16,7 +16,7 @@ fn it_typechecks_as_expected() {
 
     assert_type!(
         "fn (x) -> x.foo.bar",
-        "({ $3 | foo: { $1 | bar: $2 } }) -> $2"
+        "({ $1 | foo: { $3 | bar: $4 } }) -> $4"
     );
     assert_type!(
         "fn (x) -> [x.foo, x.bar, x.baz]",

--- a/crates/ditto-checker/tests/cmd/always_partial_application/test.stdout
+++ b/crates/ditto-checker/tests/cmd/always_partial_application/test.stdout
@@ -107,6 +107,44 @@
             "start_offset": 36,
             "end_offset": 58
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "Variable",
+                  "data": {
+                    "variable_kind": "Type",
+                    "var": 0,
+                    "source_name": null
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "Function",
+                "data": {
+                  "parameters": [
+                    {
+                      "type": "Variable",
+                      "data": {
+                        "variable_kind": "Type",
+                        "var": 1,
+                        "source_name": null
+                      }
+                    }
+                  ],
+                  "return_type": {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": "Type",
+                      "var": 0,
+                      "source_name": null
+                    }
+                  }
+                }
+              }
+            }
+          },
           "binders": [
             [
               {
@@ -134,6 +172,29 @@
               "span": {
                 "start_offset": 46,
                 "end_offset": 58
+              },
+              "function_type": {
+                "type": "Function",
+                "data": {
+                  "parameters": [
+                    {
+                      "type": "Variable",
+                      "data": {
+                        "variable_kind": "Type",
+                        "var": 1,
+                        "source_name": null
+                      }
+                    }
+                  ],
+                  "return_type": {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": "Type",
+                      "var": 0,
+                      "source_name": null
+                    }
+                  }
+                }
               },
               "binders": [
                 [

--- a/crates/ditto-checker/tests/cmd/closed_record_alias/test.stdout
+++ b/crates/ditto-checker/tests/cmd/closed_record_alias/test.stdout
@@ -148,6 +148,57 @@
             "start_offset": 85,
             "end_offset": 113
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "ConstructorAlias",
+                  "data": {
+                    "constructor_kind": "Type",
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Test"
+                        ]
+                      ],
+                      "value": "Props"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Props"
+                    },
+                    "alias_variables": [],
+                    "aliased_type": {
+                      "type": "RecordClosed",
+                      "data": {
+                        "kind": "Type",
+                        "row": {
+                          "a": {
+                            "type": "PrimConstructor",
+                            "data": "Int"
+                          },
+                          "b": {
+                            "type": "PrimConstructor",
+                            "data": "Bool"
+                          },
+                          "c": {
+                            "type": "PrimConstructor",
+                            "data": "Unit"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "PrimConstructor",
+                "data": "Int"
+              }
+            }
+          },
           "binders": [
             [
               {
@@ -354,6 +405,46 @@
                   "span": {
                     "start_offset": 129,
                     "end_offset": 158
+                  },
+                  "record_type": {
+                    "type": "ConstructorAlias",
+                    "data": {
+                      "constructor_kind": "Type",
+                      "canonical_value": {
+                        "module_name": [
+                          null,
+                          [
+                            "Test"
+                          ]
+                        ],
+                        "value": "Props"
+                      },
+                      "source_value": {
+                        "module_name": null,
+                        "value": "Props"
+                      },
+                      "alias_variables": [],
+                      "aliased_type": {
+                        "type": "RecordClosed",
+                        "data": {
+                          "kind": "Type",
+                          "row": {
+                            "a": {
+                              "type": "PrimConstructor",
+                              "data": "Int"
+                            },
+                            "b": {
+                              "type": "PrimConstructor",
+                              "data": "Bool"
+                            },
+                            "c": {
+                              "type": "PrimConstructor",
+                              "data": "Unit"
+                            }
+                          }
+                        }
+                      }
+                    }
                   },
                   "fields": {
                     "a": {

--- a/crates/ditto-checker/tests/cmd/duplicate_type_import/test.out/Maybe.ast
+++ b/crates/ditto-checker/tests/cmd/duplicate_type_import/test.out/Maybe.ast
@@ -346,6 +346,31 @@
             "start_offset": 146,
             "end_offset": 162
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [],
+              "return_type": {
+                "type": "Constructor",
+                "data": {
+                  "constructor_kind": "Type",
+                  "canonical_value": {
+                    "module_name": [
+                      null,
+                      [
+                        "Maybe"
+                      ]
+                    ],
+                    "value": "Private"
+                  },
+                  "source_value": {
+                    "module_name": null,
+                    "value": "Private"
+                  }
+                }
+              }
+            }
+          },
           "binders": [],
           "body": {
             "expression": "LocalConstructor",

--- a/crates/ditto-checker/tests/cmd/duplicate_type_import_with_different_visibility/test.out/Maybe.ast
+++ b/crates/ditto-checker/tests/cmd/duplicate_type_import_with_different_visibility/test.out/Maybe.ast
@@ -346,6 +346,31 @@
             "start_offset": 146,
             "end_offset": 162
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [],
+              "return_type": {
+                "type": "Constructor",
+                "data": {
+                  "constructor_kind": "Type",
+                  "canonical_value": {
+                    "module_name": [
+                      null,
+                      [
+                        "Maybe"
+                      ]
+                    ],
+                    "value": "Private"
+                  },
+                  "source_value": {
+                    "module_name": null,
+                    "value": "Private"
+                  }
+                }
+              }
+            }
+          },
           "binders": [],
           "body": {
             "expression": "LocalConstructor",

--- a/crates/ditto-checker/tests/cmd/duplicate_value_import/test.out/Foo.ast
+++ b/crates/ditto-checker/tests/cmd/duplicate_value_import/test.out/Foo.ast
@@ -80,6 +80,29 @@
             "start_offset": 60,
             "end_offset": 71
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "Variable",
+                  "data": {
+                    "variable_kind": "Type",
+                    "var": 0,
+                    "source_name": null
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "Variable",
+                "data": {
+                  "variable_kind": "Type",
+                  "var": 0,
+                  "source_name": null
+                }
+              }
+            }
+          },
           "binders": [
             [
               {

--- a/crates/ditto-checker/tests/cmd/export_docs/test.stdout
+++ b/crates/ditto-checker/tests/cmd/export_docs/test.stdout
@@ -152,6 +152,40 @@
             "start_offset": 245,
             "end_offset": 261
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "Variable",
+                  "data": {
+                    "variable_kind": "Type",
+                    "var": 0,
+                    "source_name": null
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "Constructor",
+                "data": {
+                  "constructor_kind": "Type",
+                  "canonical_value": {
+                    "module_name": [
+                      null,
+                      [
+                        "Test"
+                      ]
+                    ],
+                    "value": "A"
+                  },
+                  "source_value": {
+                    "module_name": null,
+                    "value": "A"
+                  }
+                }
+              }
+            }
+          },
           "binders": [
             [
               {

--- a/crates/ditto-checker/tests/cmd/float_alias/test.stdout
+++ b/crates/ditto-checker/tests/cmd/float_alias/test.stdout
@@ -10,28 +10,8 @@
         "doc_comments": [],
         "doc_position": 0,
         "value_type": {
-          "type": "ConstructorAlias",
-          "data": {
-            "constructor_kind": "Type",
-            "canonical_value": {
-              "module_name": [
-                null,
-                [
-                  "Test"
-                ]
-              ],
-              "value": "Number"
-            },
-            "source_value": {
-              "module_name": null,
-              "value": "Number"
-            },
-            "alias_variables": [],
-            "aliased_type": {
-              "type": "PrimConstructor",
-              "data": "Float"
-            }
-          }
+          "type": "PrimConstructor",
+          "data": "Float"
         }
       }
     }
@@ -67,6 +47,41 @@
           "span": {
             "start_offset": 139,
             "end_offset": 171
+          },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "ConstructorAlias",
+                  "data": {
+                    "constructor_kind": "Type",
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Test"
+                        ]
+                      ],
+                      "value": "Number"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Number"
+                    },
+                    "alias_variables": [],
+                    "aliased_type": {
+                      "type": "PrimConstructor",
+                      "data": "Float"
+                    }
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "PrimConstructor",
+                "data": "Float"
+              }
+            }
           },
           "binders": [
             [
@@ -113,28 +128,8 @@
                 "end_offset": 171
               },
               "variable_type": {
-                "type": "ConstructorAlias",
-                "data": {
-                  "constructor_kind": "Type",
-                  "canonical_value": {
-                    "module_name": [
-                      null,
-                      [
-                        "Test"
-                      ]
-                    ],
-                    "value": "Number"
-                  },
-                  "source_value": {
-                    "module_name": null,
-                    "value": "Number"
-                  },
-                  "alias_variables": [],
-                  "aliased_type": {
-                    "type": "PrimConstructor",
-                    "data": "Float"
-                  }
-                }
+                "type": "PrimConstructor",
+                "data": "Float"
               },
               "variable": "five"
             }
@@ -197,28 +192,8 @@
             "end_offset": 123
           },
           "variable_type": {
-            "type": "ConstructorAlias",
-            "data": {
-              "constructor_kind": "Type",
-              "canonical_value": {
-                "module_name": [
-                  null,
-                  [
-                    "Test"
-                  ]
-                ],
-                "value": "Number"
-              },
-              "source_value": {
-                "module_name": null,
-                "value": "Number"
-              },
-              "alias_variables": [],
-              "aliased_type": {
-                "type": "PrimConstructor",
-                "data": "Float"
-              }
-            }
+            "type": "PrimConstructor",
+            "data": "Float"
           },
           "variable": "number_five"
         }
@@ -238,28 +213,8 @@
             "end_offset": 209
           },
           "call_type": {
-            "type": "ConstructorAlias",
-            "data": {
-              "constructor_kind": "Type",
-              "canonical_value": {
-                "module_name": [
-                  null,
-                  [
-                    "Test"
-                  ]
-                ],
-                "value": "Number"
-              },
-              "source_value": {
-                "module_name": null,
-                "value": "Number"
-              },
-              "alias_variables": [],
-              "aliased_type": {
-                "type": "PrimConstructor",
-                "data": "Float"
-              }
-            }
+            "type": "PrimConstructor",
+            "data": "Float"
           },
           "function": {
             "expression": "LocalVariable",
@@ -298,28 +253,8 @@
                     }
                   ],
                   "return_type": {
-                    "type": "ConstructorAlias",
-                    "data": {
-                      "constructor_kind": "Type",
-                      "canonical_value": {
-                        "module_name": [
-                          null,
-                          [
-                            "Test"
-                          ]
-                        ],
-                        "value": "Number"
-                      },
-                      "source_value": {
-                        "module_name": null,
-                        "value": "Number"
-                      },
-                      "alias_variables": [],
-                      "aliased_type": {
-                        "type": "PrimConstructor",
-                        "data": "Float"
-                      }
-                    }
+                    "type": "PrimConstructor",
+                    "data": "Float"
                   }
                 }
               },

--- a/crates/ditto-checker/tests/cmd/foreign_value_impl/test.stdout
+++ b/crates/ditto-checker/tests/cmd/foreign_value_impl/test.stdout
@@ -32,6 +32,21 @@
             "start_offset": 70,
             "end_offset": 86
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "PrimConstructor",
+                  "data": "Int"
+                }
+              ],
+              "return_type": {
+                "type": "PrimConstructor",
+                "data": "Int"
+              }
+            }
+          },
           "binders": [
             [
               {

--- a/crates/ditto-checker/tests/cmd/homogeneous_type_alias_array/test.stdout
+++ b/crates/ditto-checker/tests/cmd/homogeneous_type_alias_array/test.stdout
@@ -343,28 +343,8 @@
                   "end_offset": 179
                 },
                 "variable_type": {
-                  "type": "ConstructorAlias",
-                  "data": {
-                    "constructor_kind": "Type",
-                    "canonical_value": {
-                      "module_name": [
-                        null,
-                        [
-                          "Test"
-                        ]
-                      ],
-                      "value": "Foo"
-                    },
-                    "source_value": {
-                      "module_name": null,
-                      "value": "Foo"
-                    },
-                    "alias_variables": [],
-                    "aliased_type": {
-                      "type": "PrimConstructor",
-                      "data": "Bool"
-                    }
-                  }
+                  "type": "PrimConstructor",
+                  "data": "Bool"
                 },
                 "variable": "foo"
               }
@@ -377,28 +357,8 @@
                   "end_offset": 184
                 },
                 "variable_type": {
-                  "type": "ConstructorAlias",
-                  "data": {
-                    "constructor_kind": "Type",
-                    "canonical_value": {
-                      "module_name": [
-                        null,
-                        [
-                          "Test"
-                        ]
-                      ],
-                      "value": "Bar"
-                    },
-                    "source_value": {
-                      "module_name": null,
-                      "value": "Bar"
-                    },
-                    "alias_variables": [],
-                    "aliased_type": {
-                      "type": "PrimConstructor",
-                      "data": "Bool"
-                    }
-                  }
+                  "type": "PrimConstructor",
+                  "data": "Bool"
                 },
                 "variable": "bar"
               }
@@ -411,28 +371,8 @@
                   "end_offset": 189
                 },
                 "variable_type": {
-                  "type": "ConstructorAlias",
-                  "data": {
-                    "constructor_kind": "Type",
-                    "canonical_value": {
-                      "module_name": [
-                        null,
-                        [
-                          "Test"
-                        ]
-                      ],
-                      "value": "Baz"
-                    },
-                    "source_value": {
-                      "module_name": null,
-                      "value": "Baz"
-                    },
-                    "alias_variables": [],
-                    "aliased_type": {
-                      "type": "PrimConstructor",
-                      "data": "Bool"
-                    }
-                  }
+                  "type": "PrimConstructor",
+                  "data": "Bool"
                 },
                 "variable": "baz"
               }

--- a/crates/ditto-checker/tests/cmd/imported_constructor_matching/test.out/Dep.ast
+++ b/crates/ditto-checker/tests/cmd/imported_constructor_matching/test.out/Dep.ast
@@ -445,6 +445,57 @@
             "start_offset": 77,
             "end_offset": 169
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "Call",
+                  "data": {
+                    "function": {
+                      "type": "Constructor",
+                      "data": {
+                        "constructor_kind": {
+                          "Function": {
+                            "parameters": [
+                              "Type"
+                            ]
+                          }
+                        },
+                        "canonical_value": {
+                          "module_name": [
+                            null,
+                            [
+                              "Dep"
+                            ]
+                          ],
+                          "value": "ABC"
+                        },
+                        "source_value": {
+                          "module_name": null,
+                          "value": "ABC"
+                        }
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "type": "Variable",
+                        "data": {
+                          "variable_kind": "Type",
+                          "var": 3,
+                          "source_name": null
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "PrimConstructor",
+                "data": "Int"
+              }
+            }
+          },
           "binders": [
             [
               {

--- a/crates/ditto-checker/tests/cmd/imported_constructor_matching/test.stdout
+++ b/crates/ditto-checker/tests/cmd/imported_constructor_matching/test.stdout
@@ -119,6 +119,89 @@
             "start_offset": 98,
             "end_offset": 203
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "Call",
+                  "data": {
+                    "function": {
+                      "type": "Constructor",
+                      "data": {
+                        "constructor_kind": {
+                          "Function": {
+                            "parameters": [
+                              "Type"
+                            ]
+                          }
+                        },
+                        "canonical_value": {
+                          "module_name": [
+                            null,
+                            [
+                              "Dep"
+                            ]
+                          ],
+                          "value": "ABC"
+                        },
+                        "source_value": {
+                          "module_name": null,
+                          "value": "ABC"
+                        }
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "type": "Variable",
+                        "data": {
+                          "variable_kind": "Type",
+                          "var": 1,
+                          "source_name": null
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "Constructor",
+                    "data": {
+                      "constructor_kind": {
+                        "Function": {
+                          "parameters": [
+                            "Type"
+                          ]
+                        }
+                      },
+                      "canonical_value": {
+                        "module_name": [
+                          null,
+                          [
+                            "Maybe"
+                          ]
+                        ],
+                        "value": "Maybe"
+                      },
+                      "source_value": {
+                        "module_name": null,
+                        "value": "Maybe"
+                      }
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "PrimConstructor",
+                      "data": "Bool"
+                    }
+                  ]
+                }
+              }
+            }
+          },
           "binders": [
             [
               {

--- a/crates/ditto-checker/tests/cmd/maybe_int_alias/test.stdout
+++ b/crates/ditto-checker/tests/cmd/maybe_int_alias/test.stdout
@@ -168,6 +168,53 @@
             "start_offset": 91,
             "end_offset": 126
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "PrimConstructor",
+                  "data": "Int"
+                }
+              ],
+              "return_type": {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "Constructor",
+                    "data": {
+                      "constructor_kind": {
+                        "Function": {
+                          "parameters": [
+                            "Type"
+                          ]
+                        }
+                      },
+                      "canonical_value": {
+                        "module_name": [
+                          null,
+                          [
+                            "Maybe"
+                          ]
+                        ],
+                        "value": "Maybe"
+                      },
+                      "source_value": {
+                        "module_name": null,
+                        "value": "Maybe"
+                      }
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "PrimConstructor",
+                      "data": "Int"
+                    }
+                  ]
+                }
+              }
+            }
+          },
           "binders": [
             [
               {

--- a/crates/ditto-checker/tests/cmd/mini_vdom/test.stdout
+++ b/crates/ditto-checker/tests/cmd/mini_vdom/test.stdout
@@ -295,6 +295,142 @@
             "start_offset": 85,
             "end_offset": 188
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "Call",
+                  "data": {
+                    "function": {
+                      "type": "PrimConstructor",
+                      "data": "Array"
+                    },
+                    "arguments": [
+                      {
+                        "type": "Constructor",
+                        "data": {
+                          "constructor_kind": "Type",
+                          "canonical_value": {
+                            "module_name": [
+                              null,
+                              [
+                                "Test"
+                              ]
+                            ],
+                            "value": "Attr"
+                          },
+                          "source_value": {
+                            "module_name": null,
+                            "value": "Attr"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "Call",
+                  "data": {
+                    "function": {
+                      "type": "PrimConstructor",
+                      "data": "Array"
+                    },
+                    "arguments": [
+                      {
+                        "type": "Call",
+                        "data": {
+                          "function": {
+                            "type": "Constructor",
+                            "data": {
+                              "constructor_kind": {
+                                "Function": {
+                                  "parameters": [
+                                    {
+                                      "Variable": 1
+                                    }
+                                  ]
+                                }
+                              },
+                              "canonical_value": {
+                                "module_name": [
+                                  null,
+                                  [
+                                    "Test"
+                                  ]
+                                ],
+                                "value": "Html"
+                              },
+                              "source_value": {
+                                "module_name": null,
+                                "value": "Html"
+                              }
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "type": "Variable",
+                              "data": {
+                                "variable_kind": {
+                                  "Variable": 1
+                                },
+                                "var": 0,
+                                "source_name": "msg"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "Constructor",
+                    "data": {
+                      "constructor_kind": {
+                        "Function": {
+                          "parameters": [
+                            {
+                              "Variable": 1
+                            }
+                          ]
+                        }
+                      },
+                      "canonical_value": {
+                        "module_name": [
+                          null,
+                          [
+                            "Test"
+                          ]
+                        ],
+                        "value": "Html"
+                      },
+                      "source_value": {
+                        "module_name": null,
+                        "value": "Html"
+                      }
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "Variable",
+                      "data": {
+                        "variable_kind": {
+                          "Variable": 1
+                        },
+                        "var": 0,
+                        "source_name": "msg"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
           "binders": [
             [
               {

--- a/crates/ditto-checker/tests/cmd/never/test.stdout
+++ b/crates/ditto-checker/tests/cmd/never/test.stdout
@@ -131,6 +131,40 @@
             "start_offset": 79,
             "end_offset": 166
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": "Type",
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Test"
+                        ]
+                      ],
+                      "value": "Never"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Never"
+                    }
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "Variable",
+                "data": {
+                  "variable_kind": "Type",
+                  "var": 0,
+                  "source_name": "a"
+                }
+              }
+            }
+          },
           "binders": [
             [
               {

--- a/crates/ditto-checker/tests/cmd/open_record_alias/test.stdout
+++ b/crates/ditto-checker/tests/cmd/open_record_alias/test.stdout
@@ -47,19 +47,74 @@
         "doc_comments": [],
         "doc_position": 0,
         "value_type": {
-          "type": "RecordClosed",
+          "type": "Call",
           "data": {
-            "kind": "Type",
-            "row": {
-              "foo": {
+            "function": {
+              "type": "ConstructorAlias",
+              "data": {
+                "constructor_kind": {
+                  "Function": {
+                    "parameters": [
+                      "Row",
+                      "Type"
+                    ]
+                  }
+                },
+                "canonical_value": {
+                  "module_name": [
+                    null,
+                    [
+                      "Test"
+                    ]
+                  ],
+                  "value": "HasFoo"
+                },
+                "source_value": {
+                  "module_name": null,
+                  "value": "HasFoo"
+                },
+                "alias_variables": [
+                  0,
+                  2
+                ],
+                "aliased_type": {
+                  "type": "RecordOpen",
+                  "data": {
+                    "kind": "Type",
+                    "var": 0,
+                    "source_name": "r",
+                    "row": {
+                      "foo": {
+                        "type": "Variable",
+                        "data": {
+                          "variable_kind": "Type",
+                          "var": 2,
+                          "source_name": "a"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "arguments": [
+              {
+                "type": "RecordClosed",
+                "data": {
+                  "kind": "Row",
+                  "row": {
+                    "bar": {
+                      "type": "PrimConstructor",
+                      "data": "Bool"
+                    }
+                  }
+                }
+              },
+              {
                 "type": "PrimConstructor",
                 "data": "Int"
-              },
-              "bar": {
-                "type": "PrimConstructor",
-                "data": "Bool"
               }
-            }
+            ]
           }
         }
       }
@@ -120,6 +175,77 @@
           "span": {
             "start_offset": 105,
             "end_offset": 128
+          },
+          "record_type": {
+            "type": "Call",
+            "data": {
+              "function": {
+                "type": "ConstructorAlias",
+                "data": {
+                  "constructor_kind": {
+                    "Function": {
+                      "parameters": [
+                        "Row",
+                        "Type"
+                      ]
+                    }
+                  },
+                  "canonical_value": {
+                    "module_name": [
+                      null,
+                      [
+                        "Test"
+                      ]
+                    ],
+                    "value": "HasFoo"
+                  },
+                  "source_value": {
+                    "module_name": null,
+                    "value": "HasFoo"
+                  },
+                  "alias_variables": [
+                    0,
+                    2
+                  ],
+                  "aliased_type": {
+                    "type": "RecordOpen",
+                    "data": {
+                      "kind": "Type",
+                      "var": 0,
+                      "source_name": "r",
+                      "row": {
+                        "foo": {
+                          "type": "Variable",
+                          "data": {
+                            "variable_kind": "Type",
+                            "var": 2,
+                            "source_name": "a"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "arguments": [
+                {
+                  "type": "RecordClosed",
+                  "data": {
+                    "kind": "Row",
+                    "row": {
+                      "bar": {
+                        "type": "PrimConstructor",
+                        "data": "Bool"
+                      }
+                    }
+                  }
+                },
+                {
+                  "type": "PrimConstructor",
+                  "data": "Int"
+                }
+              ]
+            }
           },
           "fields": {
             "foo": {

--- a/crates/ditto-checker/tests/cmd/open_record_alias_chain/test.stdout
+++ b/crates/ditto-checker/tests/cmd/open_record_alias_chain/test.stdout
@@ -248,15 +248,59 @@
         "doc_comments": [],
         "doc_position": 0,
         "value_type": {
-          "type": "RecordClosed",
+          "type": "Call",
           "data": {
-            "kind": "Type",
-            "row": {
-              "foo": {
-                "type": "PrimConstructor",
-                "data": "Int"
+            "function": {
+              "type": "ConstructorAlias",
+              "data": {
+                "constructor_kind": {
+                  "Function": {
+                    "parameters": [
+                      "Row"
+                    ]
+                  }
+                },
+                "canonical_value": {
+                  "module_name": [
+                    null,
+                    [
+                      "Test"
+                    ]
+                  ],
+                  "value": "HasFoo"
+                },
+                "source_value": {
+                  "module_name": null,
+                  "value": "HasFoo"
+                },
+                "alias_variables": [
+                  0
+                ],
+                "aliased_type": {
+                  "type": "RecordOpen",
+                  "data": {
+                    "kind": "Type",
+                    "var": 0,
+                    "source_name": "a",
+                    "row": {
+                      "foo": {
+                        "type": "PrimConstructor",
+                        "data": "Int"
+                      }
+                    }
+                  }
+                }
               }
-            }
+            },
+            "arguments": [
+              {
+                "type": "RecordClosed",
+                "data": {
+                  "kind": "Row",
+                  "row": {}
+                }
+              }
+            ]
           }
         }
       },
@@ -264,19 +308,108 @@
         "doc_comments": [],
         "doc_position": 1,
         "value_type": {
-          "type": "RecordClosed",
+          "type": "Call",
           "data": {
-            "kind": "Type",
-            "row": {
-              "foo": {
-                "type": "PrimConstructor",
-                "data": "Int"
-              },
-              "bar": {
-                "type": "PrimConstructor",
-                "data": "Float"
+            "function": {
+              "type": "ConstructorAlias",
+              "data": {
+                "constructor_kind": {
+                  "Function": {
+                    "parameters": [
+                      "Row"
+                    ]
+                  }
+                },
+                "canonical_value": {
+                  "module_name": [
+                    null,
+                    [
+                      "Test"
+                    ]
+                  ],
+                  "value": "HasFooBar"
+                },
+                "source_value": {
+                  "module_name": null,
+                  "value": "HasFooBar"
+                },
+                "alias_variables": [
+                  0
+                ],
+                "aliased_type": {
+                  "type": "Call",
+                  "data": {
+                    "function": {
+                      "type": "ConstructorAlias",
+                      "data": {
+                        "constructor_kind": {
+                          "Function": {
+                            "parameters": [
+                              "Row"
+                            ]
+                          }
+                        },
+                        "canonical_value": {
+                          "module_name": [
+                            null,
+                            [
+                              "Test"
+                            ]
+                          ],
+                          "value": "HasFoo"
+                        },
+                        "source_value": {
+                          "module_name": null,
+                          "value": "HasFoo"
+                        },
+                        "alias_variables": [
+                          0
+                        ],
+                        "aliased_type": {
+                          "type": "RecordOpen",
+                          "data": {
+                            "kind": "Type",
+                            "var": 0,
+                            "source_name": "a",
+                            "row": {
+                              "foo": {
+                                "type": "PrimConstructor",
+                                "data": "Int"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "type": "RecordOpen",
+                        "data": {
+                          "kind": "Row",
+                          "var": 0,
+                          "source_name": "b",
+                          "row": {
+                            "bar": {
+                              "type": "PrimConstructor",
+                              "data": "Float"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
               }
-            }
+            },
+            "arguments": [
+              {
+                "type": "RecordClosed",
+                "data": {
+                  "kind": "Row",
+                  "row": {}
+                }
+              }
+            ]
           }
         }
       },
@@ -284,23 +417,157 @@
         "doc_comments": [],
         "doc_position": 2,
         "value_type": {
-          "type": "RecordClosed",
+          "type": "Call",
           "data": {
-            "kind": "Type",
-            "row": {
-              "foo": {
-                "type": "PrimConstructor",
-                "data": "Int"
-              },
-              "bar": {
-                "type": "PrimConstructor",
-                "data": "Float"
-              },
-              "baz": {
-                "type": "PrimConstructor",
-                "data": "Unit"
+            "function": {
+              "type": "ConstructorAlias",
+              "data": {
+                "constructor_kind": {
+                  "Function": {
+                    "parameters": [
+                      "Row"
+                    ]
+                  }
+                },
+                "canonical_value": {
+                  "module_name": [
+                    null,
+                    [
+                      "Test"
+                    ]
+                  ],
+                  "value": "HasFooBarBaz"
+                },
+                "source_value": {
+                  "module_name": null,
+                  "value": "HasFooBarBaz"
+                },
+                "alias_variables": [
+                  0
+                ],
+                "aliased_type": {
+                  "type": "Call",
+                  "data": {
+                    "function": {
+                      "type": "ConstructorAlias",
+                      "data": {
+                        "constructor_kind": {
+                          "Function": {
+                            "parameters": [
+                              "Row"
+                            ]
+                          }
+                        },
+                        "canonical_value": {
+                          "module_name": [
+                            null,
+                            [
+                              "Test"
+                            ]
+                          ],
+                          "value": "HasFooBar"
+                        },
+                        "source_value": {
+                          "module_name": null,
+                          "value": "HasFooBar"
+                        },
+                        "alias_variables": [
+                          0
+                        ],
+                        "aliased_type": {
+                          "type": "Call",
+                          "data": {
+                            "function": {
+                              "type": "ConstructorAlias",
+                              "data": {
+                                "constructor_kind": {
+                                  "Function": {
+                                    "parameters": [
+                                      "Row"
+                                    ]
+                                  }
+                                },
+                                "canonical_value": {
+                                  "module_name": [
+                                    null,
+                                    [
+                                      "Test"
+                                    ]
+                                  ],
+                                  "value": "HasFoo"
+                                },
+                                "source_value": {
+                                  "module_name": null,
+                                  "value": "HasFoo"
+                                },
+                                "alias_variables": [
+                                  0
+                                ],
+                                "aliased_type": {
+                                  "type": "RecordOpen",
+                                  "data": {
+                                    "kind": "Type",
+                                    "var": 0,
+                                    "source_name": "a",
+                                    "row": {
+                                      "foo": {
+                                        "type": "PrimConstructor",
+                                        "data": "Int"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "arguments": [
+                              {
+                                "type": "RecordOpen",
+                                "data": {
+                                  "kind": "Row",
+                                  "var": 0,
+                                  "source_name": "b",
+                                  "row": {
+                                    "bar": {
+                                      "type": "PrimConstructor",
+                                      "data": "Float"
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "type": "RecordOpen",
+                        "data": {
+                          "kind": "Row",
+                          "var": 0,
+                          "source_name": "r",
+                          "row": {
+                            "baz": {
+                              "type": "PrimConstructor",
+                              "data": "Unit"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
               }
-            }
+            },
+            "arguments": [
+              {
+                "type": "RecordClosed",
+                "data": {
+                  "kind": "Row",
+                  "row": {}
+                }
+              }
+            ]
           }
         }
       }
@@ -569,6 +836,160 @@
             "start_offset": 303,
             "end_offset": 337
           },
+          "record_type": {
+            "type": "Call",
+            "data": {
+              "function": {
+                "type": "ConstructorAlias",
+                "data": {
+                  "constructor_kind": {
+                    "Function": {
+                      "parameters": [
+                        "Row"
+                      ]
+                    }
+                  },
+                  "canonical_value": {
+                    "module_name": [
+                      null,
+                      [
+                        "Test"
+                      ]
+                    ],
+                    "value": "HasFooBarBaz"
+                  },
+                  "source_value": {
+                    "module_name": null,
+                    "value": "HasFooBarBaz"
+                  },
+                  "alias_variables": [
+                    0
+                  ],
+                  "aliased_type": {
+                    "type": "Call",
+                    "data": {
+                      "function": {
+                        "type": "ConstructorAlias",
+                        "data": {
+                          "constructor_kind": {
+                            "Function": {
+                              "parameters": [
+                                "Row"
+                              ]
+                            }
+                          },
+                          "canonical_value": {
+                            "module_name": [
+                              null,
+                              [
+                                "Test"
+                              ]
+                            ],
+                            "value": "HasFooBar"
+                          },
+                          "source_value": {
+                            "module_name": null,
+                            "value": "HasFooBar"
+                          },
+                          "alias_variables": [
+                            0
+                          ],
+                          "aliased_type": {
+                            "type": "Call",
+                            "data": {
+                              "function": {
+                                "type": "ConstructorAlias",
+                                "data": {
+                                  "constructor_kind": {
+                                    "Function": {
+                                      "parameters": [
+                                        "Row"
+                                      ]
+                                    }
+                                  },
+                                  "canonical_value": {
+                                    "module_name": [
+                                      null,
+                                      [
+                                        "Test"
+                                      ]
+                                    ],
+                                    "value": "HasFoo"
+                                  },
+                                  "source_value": {
+                                    "module_name": null,
+                                    "value": "HasFoo"
+                                  },
+                                  "alias_variables": [
+                                    0
+                                  ],
+                                  "aliased_type": {
+                                    "type": "RecordOpen",
+                                    "data": {
+                                      "kind": "Type",
+                                      "var": 0,
+                                      "source_name": "a",
+                                      "row": {
+                                        "foo": {
+                                          "type": "PrimConstructor",
+                                          "data": "Int"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "arguments": [
+                                {
+                                  "type": "RecordOpen",
+                                  "data": {
+                                    "kind": "Row",
+                                    "var": 0,
+                                    "source_name": "b",
+                                    "row": {
+                                      "bar": {
+                                        "type": "PrimConstructor",
+                                        "data": "Float"
+                                      }
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "type": "RecordOpen",
+                          "data": {
+                            "kind": "Row",
+                            "var": 0,
+                            "source_name": "r",
+                            "row": {
+                              "baz": {
+                                "type": "PrimConstructor",
+                                "data": "Unit"
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "arguments": [
+                {
+                  "type": "RecordClosed",
+                  "data": {
+                    "kind": "Row",
+                    "row": {}
+                  }
+                }
+              ]
+            }
+          },
           "fields": {
             "foo": {
               "expression": "Int",
@@ -628,6 +1049,111 @@
             "start_offset": 245,
             "end_offset": 267
           },
+          "record_type": {
+            "type": "Call",
+            "data": {
+              "function": {
+                "type": "ConstructorAlias",
+                "data": {
+                  "constructor_kind": {
+                    "Function": {
+                      "parameters": [
+                        "Row"
+                      ]
+                    }
+                  },
+                  "canonical_value": {
+                    "module_name": [
+                      null,
+                      [
+                        "Test"
+                      ]
+                    ],
+                    "value": "HasFooBar"
+                  },
+                  "source_value": {
+                    "module_name": null,
+                    "value": "HasFooBar"
+                  },
+                  "alias_variables": [
+                    0
+                  ],
+                  "aliased_type": {
+                    "type": "Call",
+                    "data": {
+                      "function": {
+                        "type": "ConstructorAlias",
+                        "data": {
+                          "constructor_kind": {
+                            "Function": {
+                              "parameters": [
+                                "Row"
+                              ]
+                            }
+                          },
+                          "canonical_value": {
+                            "module_name": [
+                              null,
+                              [
+                                "Test"
+                              ]
+                            ],
+                            "value": "HasFoo"
+                          },
+                          "source_value": {
+                            "module_name": null,
+                            "value": "HasFoo"
+                          },
+                          "alias_variables": [
+                            0
+                          ],
+                          "aliased_type": {
+                            "type": "RecordOpen",
+                            "data": {
+                              "kind": "Type",
+                              "var": 0,
+                              "source_name": "a",
+                              "row": {
+                                "foo": {
+                                  "type": "PrimConstructor",
+                                  "data": "Int"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "arguments": [
+                        {
+                          "type": "RecordOpen",
+                          "data": {
+                            "kind": "Row",
+                            "var": 0,
+                            "source_name": "b",
+                            "row": {
+                              "bar": {
+                                "type": "PrimConstructor",
+                                "data": "Float"
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "arguments": [
+                {
+                  "type": "RecordClosed",
+                  "data": {
+                    "kind": "Row",
+                    "row": {}
+                  }
+                }
+              ]
+            }
+          },
           "fields": {
             "foo": {
               "expression": "Int",
@@ -673,6 +1199,62 @@
           "span": {
             "start_offset": 206,
             "end_offset": 217
+          },
+          "record_type": {
+            "type": "Call",
+            "data": {
+              "function": {
+                "type": "ConstructorAlias",
+                "data": {
+                  "constructor_kind": {
+                    "Function": {
+                      "parameters": [
+                        "Row"
+                      ]
+                    }
+                  },
+                  "canonical_value": {
+                    "module_name": [
+                      null,
+                      [
+                        "Test"
+                      ]
+                    ],
+                    "value": "HasFoo"
+                  },
+                  "source_value": {
+                    "module_name": null,
+                    "value": "HasFoo"
+                  },
+                  "alias_variables": [
+                    0
+                  ],
+                  "aliased_type": {
+                    "type": "RecordOpen",
+                    "data": {
+                      "kind": "Type",
+                      "var": 0,
+                      "source_name": "a",
+                      "row": {
+                        "foo": {
+                          "type": "PrimConstructor",
+                          "data": "Int"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "arguments": [
+                {
+                  "type": "RecordClosed",
+                  "data": {
+                    "kind": "Row",
+                    "row": {}
+                  }
+                }
+              ]
+            }
           },
           "fields": {
             "foo": {

--- a/crates/ditto-checker/tests/cmd/option_alias/test.stdout
+++ b/crates/ditto-checker/tests/cmd/option_alias/test.stdout
@@ -74,7 +74,7 @@
               "type": "Call",
               "data": {
                 "function": {
-                  "type": "Constructor",
+                  "type": "ConstructorAlias",
                   "data": {
                     "constructor_kind": {
                       "Function": {
@@ -85,14 +85,60 @@
                     },
                     "canonical_value": {
                       "module_name": [
-                        "base",
+                        null,
                         [
-                          "Maybe"
+                          "Test"
                         ]
                       ],
-                      "value": "Maybe"
+                      "value": "Option"
                     },
-                    "source_value": null
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Option"
+                    },
+                    "alias_variables": [
+                      0
+                    ],
+                    "aliased_type": {
+                      "type": "Call",
+                      "data": {
+                        "function": {
+                          "type": "Constructor",
+                          "data": {
+                            "constructor_kind": {
+                              "Function": {
+                                "parameters": [
+                                  "Type"
+                                ]
+                              }
+                            },
+                            "canonical_value": {
+                              "module_name": [
+                                "base",
+                                [
+                                  "Maybe"
+                                ]
+                              ],
+                              "value": "Maybe"
+                            },
+                            "source_value": {
+                              "module_name": null,
+                              "value": "Maybe"
+                            }
+                          }
+                        },
+                        "arguments": [
+                          {
+                            "type": "Variable",
+                            "data": {
+                              "variable_kind": "Type",
+                              "var": 0,
+                              "source_name": "a"
+                            }
+                          }
+                        ]
+                      }
+                    }
                   }
                 },
                 "arguments": [
@@ -244,6 +290,95 @@
             "start_offset": 144,
             "end_offset": 177
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [],
+              "return_type": {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "ConstructorAlias",
+                    "data": {
+                      "constructor_kind": {
+                        "Function": {
+                          "parameters": [
+                            "Type"
+                          ]
+                        }
+                      },
+                      "canonical_value": {
+                        "module_name": [
+                          null,
+                          [
+                            "Test"
+                          ]
+                        ],
+                        "value": "Option"
+                      },
+                      "source_value": {
+                        "module_name": null,
+                        "value": "Option"
+                      },
+                      "alias_variables": [
+                        0
+                      ],
+                      "aliased_type": {
+                        "type": "Call",
+                        "data": {
+                          "function": {
+                            "type": "Constructor",
+                            "data": {
+                              "constructor_kind": {
+                                "Function": {
+                                  "parameters": [
+                                    "Type"
+                                  ]
+                                }
+                              },
+                              "canonical_value": {
+                                "module_name": [
+                                  "base",
+                                  [
+                                    "Maybe"
+                                  ]
+                                ],
+                                "value": "Maybe"
+                              },
+                              "source_value": {
+                                "module_name": null,
+                                "value": "Maybe"
+                              }
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "type": "Variable",
+                              "data": {
+                                "variable_kind": "Type",
+                                "var": 0,
+                                "source_name": "a"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "Variable",
+                      "data": {
+                        "variable_kind": "Type",
+                        "var": 0,
+                        "source_name": "a"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
           "binders": [],
           "body": {
             "expression": "ImportedConstructor",
@@ -256,7 +391,7 @@
                 "type": "Call",
                 "data": {
                   "function": {
-                    "type": "Constructor",
+                    "type": "ConstructorAlias",
                     "data": {
                       "constructor_kind": {
                         "Function": {
@@ -267,14 +402,60 @@
                       },
                       "canonical_value": {
                         "module_name": [
-                          "base",
+                          null,
                           [
-                            "Maybe"
+                            "Test"
                           ]
                         ],
-                        "value": "Maybe"
+                        "value": "Option"
                       },
-                      "source_value": null
+                      "source_value": {
+                        "module_name": null,
+                        "value": "Option"
+                      },
+                      "alias_variables": [
+                        0
+                      ],
+                      "aliased_type": {
+                        "type": "Call",
+                        "data": {
+                          "function": {
+                            "type": "Constructor",
+                            "data": {
+                              "constructor_kind": {
+                                "Function": {
+                                  "parameters": [
+                                    "Type"
+                                  ]
+                                }
+                              },
+                              "canonical_value": {
+                                "module_name": [
+                                  "base",
+                                  [
+                                    "Maybe"
+                                  ]
+                                ],
+                                "value": "Maybe"
+                              },
+                              "source_value": {
+                                "module_name": null,
+                                "value": "Maybe"
+                              }
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "type": "Variable",
+                              "data": {
+                                "variable_kind": "Type",
+                                "var": 0,
+                                "source_name": "a"
+                              }
+                            }
+                          ]
+                        }
+                      }
                     }
                   },
                   "arguments": [
@@ -315,6 +496,58 @@
           "span": {
             "start_offset": 98,
             "end_offset": 135
+          },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "Variable",
+                  "data": {
+                    "variable_kind": "Type",
+                    "var": 0,
+                    "source_name": "a"
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "Constructor",
+                    "data": {
+                      "constructor_kind": {
+                        "Function": {
+                          "parameters": [
+                            "Type"
+                          ]
+                        }
+                      },
+                      "canonical_value": {
+                        "module_name": [
+                          "base",
+                          [
+                            "Maybe"
+                          ]
+                        ],
+                        "value": "Maybe"
+                      },
+                      "source_value": null
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "Variable",
+                      "data": {
+                        "variable_kind": "Type",
+                        "var": 0,
+                        "source_name": "a"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
           },
           "binders": [
             [

--- a/crates/ditto-checker/tests/cmd/record_extension_newtype/test.stdout
+++ b/crates/ditto-checker/tests/cmd/record_extension_newtype/test.stdout
@@ -586,7 +586,7 @@
                       "type": "RecordOpen",
                       "data": {
                         "kind": "Type",
-                        "var": 6,
+                        "var": 8,
                         "source_name": null,
                         "row": {
                           "foo": {
@@ -1457,6 +1457,26 @@
                                     "start_offset": 853,
                                     "end_offset": 895
                                   },
+                                  "record_type": {
+                                    "type": "RecordClosed",
+                                    "data": {
+                                      "kind": "Type",
+                                      "row": {
+                                        "foo": {
+                                          "type": "PrimConstructor",
+                                          "data": "Int"
+                                        },
+                                        "bar": {
+                                          "type": "PrimConstructor",
+                                          "data": "Int"
+                                        },
+                                        "baz": {
+                                          "type": "PrimConstructor",
+                                          "data": "Int"
+                                        }
+                                      }
+                                    }
+                                  },
                                   "fields": {
                                     "foo": {
                                       "expression": "Int",
@@ -1833,6 +1853,26 @@
                             "start_offset": 702,
                             "end_offset": 734
                           },
+                          "record_type": {
+                            "type": "RecordClosed",
+                            "data": {
+                              "kind": "Type",
+                              "row": {
+                                "foo": {
+                                  "type": "PrimConstructor",
+                                  "data": "Int"
+                                },
+                                "bar": {
+                                  "type": "PrimConstructor",
+                                  "data": "Int"
+                                },
+                                "baz": {
+                                  "type": "PrimConstructor",
+                                  "data": "Unit"
+                                }
+                              }
+                            }
+                          },
                           "fields": {
                             "foo": {
                               "expression": "Int",
@@ -2178,6 +2218,22 @@
                             "start_offset": 618,
                             "end_offset": 637
                           },
+                          "record_type": {
+                            "type": "RecordClosed",
+                            "data": {
+                              "kind": "Type",
+                              "row": {
+                                "foo": {
+                                  "type": "PrimConstructor",
+                                  "data": "Int"
+                                },
+                                "bar": {
+                                  "type": "PrimConstructor",
+                                  "data": "Int"
+                                }
+                              }
+                            }
+                          },
                           "fields": {
                             "foo": {
                               "expression": "Int",
@@ -2231,6 +2287,69 @@
           "span": {
             "start_offset": 396,
             "end_offset": 456
+          },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "Call",
+                  "data": {
+                    "function": {
+                      "type": "Constructor",
+                      "data": {
+                        "constructor_kind": {
+                          "Function": {
+                            "parameters": [
+                              "Row"
+                            ]
+                          }
+                        },
+                        "canonical_value": {
+                          "module_name": [
+                            null,
+                            [
+                              "Test"
+                            ]
+                          ],
+                          "value": "ExtendMe"
+                        },
+                        "source_value": {
+                          "module_name": null,
+                          "value": "ExtendMe"
+                        }
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "type": "RecordClosed",
+                        "data": {
+                          "kind": "Type",
+                          "row": {
+                            "foo": {
+                              "type": "PrimConstructor",
+                              "data": "Int"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "RecordClosed",
+                "data": {
+                  "kind": "Type",
+                  "row": {
+                    "foo": {
+                      "type": "PrimConstructor",
+                      "data": "Int"
+                    }
+                  }
+                }
+              }
+            }
           },
           "binders": [
             [
@@ -2427,6 +2546,73 @@
           "span": {
             "start_offset": 310,
             "end_offset": 374
+          },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "Call",
+                  "data": {
+                    "function": {
+                      "type": "Constructor",
+                      "data": {
+                        "constructor_kind": {
+                          "Function": {
+                            "parameters": [
+                              "Row"
+                            ]
+                          }
+                        },
+                        "canonical_value": {
+                          "module_name": [
+                            null,
+                            [
+                              "Test"
+                            ]
+                          ],
+                          "value": "ExtendMe"
+                        },
+                        "source_value": {
+                          "module_name": null,
+                          "value": "ExtendMe"
+                        }
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "type": "RecordOpen",
+                        "data": {
+                          "kind": "Type",
+                          "var": 4,
+                          "source_name": "r",
+                          "row": {
+                            "foo": {
+                              "type": "PrimConstructor",
+                              "data": "Int"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "RecordOpen",
+                "data": {
+                  "kind": "Type",
+                  "var": 4,
+                  "source_name": "r",
+                  "row": {
+                    "foo": {
+                      "type": "PrimConstructor",
+                      "data": "Int"
+                    }
+                  }
+                }
+              }
+            }
           },
           "binders": [
             [
@@ -2630,6 +2816,63 @@
             "start_offset": 468,
             "end_offset": 507
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "Call",
+                  "data": {
+                    "function": {
+                      "type": "Constructor",
+                      "data": {
+                        "constructor_kind": {
+                          "Function": {
+                            "parameters": [
+                              "Row"
+                            ]
+                          }
+                        },
+                        "canonical_value": {
+                          "module_name": [
+                            null,
+                            [
+                              "Test"
+                            ]
+                          ],
+                          "value": "ExtendMe"
+                        },
+                        "source_value": {
+                          "module_name": null,
+                          "value": "ExtendMe"
+                        }
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "type": "RecordOpen",
+                        "data": {
+                          "kind": "Type",
+                          "var": 8,
+                          "source_name": null,
+                          "row": {
+                            "foo": {
+                              "type": "PrimConstructor",
+                              "data": "Int"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "PrimConstructor",
+                "data": "Int"
+              }
+            }
+          },
           "binders": [
             [
               {
@@ -2674,7 +2917,7 @@
                       "type": "RecordOpen",
                       "data": {
                         "kind": "Type",
-                        "var": 6,
+                        "var": 8,
                         "source_name": null,
                         "row": {
                           "foo": {
@@ -2711,7 +2954,7 @@
                     "type": "RecordOpen",
                     "data": {
                       "kind": "Type",
-                      "var": 6,
+                      "var": 8,
                       "source_name": null,
                       "row": {
                         "foo": {
@@ -2765,7 +3008,7 @@
                                     "type": "RecordOpen",
                                     "data": {
                                       "kind": "Type",
-                                      "var": 6,
+                                      "var": 8,
                                       "source_name": null,
                                       "row": {
                                         "foo": {
@@ -2783,7 +3026,7 @@
                             "type": "RecordOpen",
                             "data": {
                               "kind": "Type",
-                              "var": 6,
+                              "var": 8,
                               "source_name": null,
                               "row": {
                                 "foo": {
@@ -2840,7 +3083,7 @@
                                   "type": "RecordOpen",
                                   "data": {
                                     "kind": "Type",
-                                    "var": 6,
+                                    "var": 8,
                                     "source_name": null,
                                     "row": {
                                       "foo": {
@@ -3020,6 +3263,26 @@
                   "span": {
                     "start_offset": 211,
                     "end_offset": 240
+                  },
+                  "record_type": {
+                    "type": "RecordClosed",
+                    "data": {
+                      "kind": "Type",
+                      "row": {
+                        "foo": {
+                          "type": "PrimConstructor",
+                          "data": "Int"
+                        },
+                        "bar": {
+                          "type": "PrimConstructor",
+                          "data": "Int"
+                        },
+                        "baz": {
+                          "type": "PrimConstructor",
+                          "data": "Int"
+                        }
+                      }
+                    }
                   },
                   "fields": {
                     "foo": {
@@ -3223,6 +3486,22 @@
                     "start_offset": 131,
                     "end_offset": 151
                   },
+                  "record_type": {
+                    "type": "RecordClosed",
+                    "data": {
+                      "kind": "Type",
+                      "row": {
+                        "foo": {
+                          "type": "PrimConstructor",
+                          "data": "Int"
+                        },
+                        "bar": {
+                          "type": "PrimConstructor",
+                          "data": "Int"
+                        }
+                      }
+                    }
+                  },
                   "fields": {
                     "foo": {
                       "expression": "Int",
@@ -3398,6 +3677,18 @@
                   "span": {
                     "start_offset": 96,
                     "end_offset": 107
+                  },
+                  "record_type": {
+                    "type": "RecordClosed",
+                    "data": {
+                      "kind": "Type",
+                      "row": {
+                        "foo": {
+                          "type": "PrimConstructor",
+                          "data": "Int"
+                        }
+                      }
+                    }
                   },
                   "fields": {
                     "foo": {

--- a/crates/ditto-checker/tests/cmd/result_alias_effect_matching/test.stdout
+++ b/crates/ditto-checker/tests/cmd/result_alias_effect_matching/test.stdout
@@ -225,6 +225,100 @@
             "start_offset": 110,
             "end_offset": 264
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "Call",
+                  "data": {
+                    "function": {
+                      "type": "PrimConstructor",
+                      "data": "Effect"
+                    },
+                    "arguments": [
+                      {
+                        "type": "ConstructorAlias",
+                        "data": {
+                          "constructor_kind": "Type",
+                          "canonical_value": {
+                            "module_name": [
+                              null,
+                              [
+                                "Test"
+                              ]
+                            ],
+                            "value": "Result"
+                          },
+                          "source_value": {
+                            "module_name": null,
+                            "value": "Result"
+                          },
+                          "alias_variables": [],
+                          "aliased_type": {
+                            "type": "Call",
+                            "data": {
+                              "function": {
+                                "type": "Constructor",
+                                "data": {
+                                  "constructor_kind": {
+                                    "Function": {
+                                      "parameters": [
+                                        "Type",
+                                        "Type"
+                                      ]
+                                    }
+                                  },
+                                  "canonical_value": {
+                                    "module_name": [
+                                      null,
+                                      [
+                                        "Result"
+                                      ]
+                                    ],
+                                    "value": "Result"
+                                  },
+                                  "source_value": {
+                                    "module_name": "Result",
+                                    "value": "Result"
+                                  }
+                                }
+                              },
+                              "arguments": [
+                                {
+                                  "type": "PrimConstructor",
+                                  "data": "Int"
+                                },
+                                {
+                                  "type": "PrimConstructor",
+                                  "data": "String"
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "PrimConstructor",
+                    "data": "Effect"
+                  },
+                  "arguments": [
+                    {
+                      "type": "PrimConstructor",
+                      "data": "Bool"
+                    }
+                  ]
+                }
+              }
+            }
+          },
           "binders": [
             [
               {
@@ -316,6 +410,21 @@
               "span": {
                 "start_offset": 152,
                 "end_offset": 264
+              },
+              "effect_type": {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "PrimConstructor",
+                    "data": "Effect"
+                  },
+                  "arguments": [
+                    {
+                      "type": "PrimConstructor",
+                      "data": "Bool"
+                    }
+                  ]
+                }
               },
               "return_type": {
                 "type": "PrimConstructor",

--- a/crates/ditto-checker/tests/cmd/result_alias_matching/test.stdout
+++ b/crates/ditto-checker/tests/cmd/result_alias_matching/test.stdout
@@ -203,6 +203,78 @@
             "start_offset": 110,
             "end_offset": 219
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "ConstructorAlias",
+                  "data": {
+                    "constructor_kind": "Type",
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Test"
+                        ]
+                      ],
+                      "value": "Result"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Result"
+                    },
+                    "alias_variables": [],
+                    "aliased_type": {
+                      "type": "Call",
+                      "data": {
+                        "function": {
+                          "type": "Constructor",
+                          "data": {
+                            "constructor_kind": {
+                              "Function": {
+                                "parameters": [
+                                  "Type",
+                                  "Type"
+                                ]
+                              }
+                            },
+                            "canonical_value": {
+                              "module_name": [
+                                null,
+                                [
+                                  "Result"
+                                ]
+                              ],
+                              "value": "Result"
+                            },
+                            "source_value": {
+                              "module_name": "Result",
+                              "value": "Result"
+                            }
+                          }
+                        },
+                        "arguments": [
+                          {
+                            "type": "PrimConstructor",
+                            "data": "Int"
+                          },
+                          {
+                            "type": "PrimConstructor",
+                            "data": "String"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            }
+          },
           "binders": [
             [
               {

--- a/crates/ditto-checker/tests/cmd/simple_type_imports/test.out/Maybe.ast
+++ b/crates/ditto-checker/tests/cmd/simple_type_imports/test.out/Maybe.ast
@@ -346,6 +346,31 @@
             "start_offset": 146,
             "end_offset": 162
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [],
+              "return_type": {
+                "type": "Constructor",
+                "data": {
+                  "constructor_kind": "Type",
+                  "canonical_value": {
+                    "module_name": [
+                      null,
+                      [
+                        "Maybe"
+                      ]
+                    ],
+                    "value": "Private"
+                  },
+                  "source_value": {
+                    "module_name": null,
+                    "value": "Private"
+                  }
+                }
+              }
+            }
+          },
           "binders": [],
           "body": {
             "expression": "LocalConstructor",

--- a/crates/ditto-checker/tests/cmd/simple_value_imports/test.out/Foo.ast
+++ b/crates/ditto-checker/tests/cmd/simple_value_imports/test.out/Foo.ast
@@ -80,6 +80,29 @@
             "start_offset": 60,
             "end_offset": 71
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "Variable",
+                  "data": {
+                    "variable_kind": "Type",
+                    "var": 0,
+                    "source_name": null
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "Variable",
+                "data": {
+                  "variable_kind": "Type",
+                  "var": 0,
+                  "source_name": null
+                }
+              }
+            }
+          },
           "binders": [
             [
               {

--- a/crates/ditto-checker/tests/cmd/unused_value_declaration/test.stdout
+++ b/crates/ditto-checker/tests/cmd/unused_value_declaration/test.stdout
@@ -59,6 +59,29 @@
             "start_offset": 65,
             "end_offset": 76
           },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "Variable",
+                  "data": {
+                    "variable_kind": "Type",
+                    "var": 0,
+                    "source_name": null
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "Variable",
+                "data": {
+                  "variable_kind": "Type",
+                  "var": 0,
+                  "source_name": null
+                }
+              }
+            }
+          },
           "binders": [
             [
               {

--- a/crates/ditto-checker/tests/cmd/variable_alias/test.stdin
+++ b/crates/ditto-checker/tests/cmd/variable_alias/test.stdin
@@ -2,8 +2,6 @@ module Test exports (..);
 
 type alias WhyTho(a) = a;
 
-identity = fn (a: WhyTho(a)): a -> a;
-
--- FIXME: type information gets dropped if `WhyTho(a)` is the return type annotation
+identity = fn (a: WhyTho(a)) -> a;
 
 five : Float = identity(5.0);

--- a/crates/ditto-checker/tests/cmd/variable_alias/test.stdout
+++ b/crates/ditto-checker/tests/cmd/variable_alias/test.stdout
@@ -32,9 +32,7 @@
     "constructors": {},
     "values": {
       "five": {
-        "doc_comments": [
-          "FIXME: type information gets dropped if `WhyTho(a)` is the return type annotation"
-        ],
+        "doc_comments": [],
         "doc_position": 0,
         "value_type": {
           "type": "Call",
@@ -237,7 +235,116 @@
         "data": {
           "span": {
             "start_offset": 65,
-            "end_offset": 90
+            "end_offset": 87
+          },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "Call",
+                  "data": {
+                    "function": {
+                      "type": "ConstructorAlias",
+                      "data": {
+                        "constructor_kind": {
+                          "Function": {
+                            "parameters": [
+                              "Type"
+                            ]
+                          }
+                        },
+                        "canonical_value": {
+                          "module_name": [
+                            null,
+                            [
+                              "Test"
+                            ]
+                          ],
+                          "value": "WhyTho"
+                        },
+                        "source_value": {
+                          "module_name": null,
+                          "value": "WhyTho"
+                        },
+                        "alias_variables": [
+                          0
+                        ],
+                        "aliased_type": {
+                          "type": "Variable",
+                          "data": {
+                            "variable_kind": "Type",
+                            "var": 0,
+                            "source_name": "a"
+                          }
+                        }
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "type": "Variable",
+                        "data": {
+                          "variable_kind": "Type",
+                          "var": 0,
+                          "source_name": "a"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "ConstructorAlias",
+                    "data": {
+                      "constructor_kind": {
+                        "Function": {
+                          "parameters": [
+                            "Type"
+                          ]
+                        }
+                      },
+                      "canonical_value": {
+                        "module_name": [
+                          null,
+                          [
+                            "Test"
+                          ]
+                        ],
+                        "value": "WhyTho"
+                      },
+                      "source_value": {
+                        "module_name": null,
+                        "value": "WhyTho"
+                      },
+                      "alias_variables": [
+                        0
+                      ],
+                      "aliased_type": {
+                        "type": "Variable",
+                        "data": {
+                          "variable_kind": "Type",
+                          "var": 0,
+                          "source_name": "a"
+                        }
+                      }
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "Variable",
+                      "data": {
+                        "variable_kind": "Type",
+                        "var": 0,
+                        "source_name": "a"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
           },
           "binders": [
             [
@@ -307,8 +414,8 @@
             "expression": "LocalVariable",
             "data": {
               "span": {
-                "start_offset": 89,
-                "end_offset": 90
+                "start_offset": 86,
+                "end_offset": 87
               },
               "variable_type": {
                 "type": "Call",
@@ -368,19 +475,17 @@
       }
     },
     "five": {
-      "doc_comments": [
-        "FIXME: type information gets dropped if `WhyTho(a)` is the return type annotation"
-      ],
+      "doc_comments": [],
       "name_span": {
-        "start_offset": 179,
-        "end_offset": 183
+        "start_offset": 90,
+        "end_offset": 94
       },
       "expression": {
         "expression": "Call",
         "data": {
           "span": {
-            "start_offset": 194,
-            "end_offset": 207
+            "start_offset": 105,
+            "end_offset": 118
           },
           "call_type": {
             "type": "Call",
@@ -429,8 +534,8 @@
             "expression": "LocalVariable",
             "data": {
               "span": {
-                "start_offset": 194,
-                "end_offset": 202
+                "start_offset": 105,
+                "end_offset": 113
               },
               "variable_type": {
                 "type": "Function",
@@ -534,8 +639,8 @@
                 "expression": "Float",
                 "data": {
                   "span": {
-                    "start_offset": 203,
-                    "end_offset": 206
+                    "start_offset": 114,
+                    "end_offset": 117
                   },
                   "value": "5.0",
                   "value_type": {

--- a/crates/ditto-checker/tests/trycmd_tests.rs
+++ b/crates/ditto-checker/tests/trycmd_tests.rs
@@ -1,4 +1,4 @@
 #[test]
 fn checker_tests() {
-    trycmd::TestCases::new().case("tests/cmd/function_type_alias/*.toml");
+    trycmd::TestCases::new().case("tests/cmd/*/*.toml");
 }


### PR DESCRIPTION
[As promised](https://github.com/ditto-lang/ditto/pull/111#issue-1511819930)...

> Because we're not hanging on to that type annotation anywhere grimacing I'm gonna fix that...

We now properly store type annotations. Which is important since type aliases were introduced in #62.