### PR TITLE
Assign matched expressions to variables in generated JavaScript ⚡

### DIFF
--- a/crates/ditto-codegen-js/src/optimize/mod.rs
+++ b/crates/ditto-codegen-js/src/optimize/mod.rs
@@ -673,12 +673,12 @@ mod test {
         );
         assert_optimized!(
             "fn (a) -> match a with | A -> 5 end",
-            "(a) => (a[0] === \"A\")?5:(() => {throw new Error(\"Pattern match error\");})()",
+            "(a) => {if ((a[0] === \"A\")){return 5;}throw new Error(\"Pattern match error\");}",
             &[]
         );
         assert_optimized!(
             "fn (bc) -> match bc with | B -> 1 | C -> 2 end",
-            "(bc) => (bc[0] === \"B\")?1:(bc[0] === \"C\")?2:(() => {throw new Error(\"Pattern match error\");})()",
+            "(bc) => {if ((bc[0] === \"B\")){return 1;}if ((bc[0] === \"C\")){return 2;}throw new Error(\"Pattern match error\");}",
             &[]
         );
     }

--- a/crates/ditto-codegen-js/tests/golden/match_expressions.ditto
+++ b/crates/ditto-codegen-js/tests/golden/match_expressions.ditto
@@ -57,3 +57,11 @@ to_string = fn (abc) ->
     | B -> "C"
     | C -> "C"
     end;
+
+id = fn (a) -> a;
+
+complex_matched_expresion = fn (x) ->
+    match id(id(id(id(id(id(x)))))) with
+    | Just(y) -> [y]
+    | Nothing -> [2]
+    end;

--- a/crates/ditto-codegen-js/tests/golden/match_expressions.js
+++ b/crates/ditto-codegen-js/tests/golden/match_expressions.js
@@ -8,6 +8,20 @@ function ManyFields($0, $1, $2, $3) {
   return ["ManyFields", $0, $1, $2, $3];
 }
 const Nothing = ["Nothing"];
+function id(a) {
+  return a;
+}
+function complex_matched_expresion(x) {
+  const $0 = id(id(id(id(id(id(x))))));
+  if ($0[0] === "Just") {
+    const y = $0[1];
+    return [y];
+  }
+  if ($0[0] === "Nothing") {
+    return [2];
+  }
+  throw new Error("Pattern match error");
+}
 function to_string(abc) {
   if (abc[0] === "A") {
     return "A";
@@ -92,8 +106,10 @@ export {
   Just,
   ManyFields,
   Nothing,
+  complex_matched_expresion,
   effect_arms,
   function_arms,
+  id,
   is_just,
   many_fields_to_array,
   mk_five,


### PR DESCRIPTION
Updates the JavaScript code generator to assign expressions being matched against. This avoids potentially expensive re-evaluations.

Given the following module:

```ditto
module Example exports (..);


some = fn (a) -> a;

long = fn (a) -> a;

convoluted = fn (a) -> a;

function = fn (a) -> a;

type ABC =
    | A(Int)
    | B(Int)
    | C(Int);

example = fn (abc) ->
    match abc
    |> some
    |> long
    |> convoluted
    |> function with
    | A(i) -> i
    | B(i) -> i
    | C(i) -> i
    end;
```

Before this PR would generate:

```js
function example(abc) {
  if ($function(convoluted(long(some(abc))))[0] === "A") {
    const i = $function(convoluted(long(some(abc))))[1];
    return i;
  }
  if ($function(convoluted(long(some(abc))))[0] === "B") {
    const i = $function(convoluted(long(some(abc))))[1];
    return i;
  }
  if ($function(convoluted(long(some(abc))))[0] === "C") {
    const i = $function(convoluted(long(some(abc))))[1];
    return i;
  }
  throw new Error("Pattern match error");
}
export { convoluted, example, $function, long, some, A, B, C };
```

But now generates:

```js
function example(abc) {
  const $0 = $function(convoluted(long(some(abc))));
  if ($0[0] === "A") {
    const i = $0[1];
    return i;
  }
  if ($0[0] === "B") {
    const i = $0[1];
    return i;
  }
  if ($0[0] === "C") {
    const i = $0[1];
    return i;
  }
  throw new Error("Pattern match error");
}
```