### PR TITLE
Use an `IndexSet` for type and kind scheme variables :grimacing: 

### DIFF
--- a/crates/ditto-checker/src/kindchecker/mod.rs
+++ b/crates/ditto-checker/src/kindchecker/mod.rs
@@ -11,8 +11,8 @@ pub use substitution::*;
 use crate::result::{Result, TypeError};
 use ditto_ast::{Kind, Name, QualifiedProperName, Row, Span, Type};
 use ditto_cst as cst;
+use indexmap::IndexSet;
 use non_empty_vec::NonEmpty;
-use std::collections::HashSet;
 
 #[cfg(test)]
 pub fn kindcheck(
@@ -377,13 +377,13 @@ fn occurs_check(span: Span, var: usize, kind: &Kind) -> Result<()> {
     Ok(())
 }
 
-pub fn kind_variables(kind: &Kind) -> HashSet<usize> {
-    let mut accum = HashSet::new();
+pub fn kind_variables(kind: &Kind) -> IndexSet<usize> {
+    let mut accum = IndexSet::new();
     kind_variables_rec(kind, &mut accum);
     accum
 }
 
-fn kind_variables_rec(kind: &Kind, accum: &mut HashSet<usize>) {
+fn kind_variables_rec(kind: &Kind, accum: &mut IndexSet<usize>) {
     match kind {
         Kind::Variable(var) => {
             accum.insert(*var);

--- a/crates/ditto-checker/src/typechecker/common.rs
+++ b/crates/ditto-checker/src/typechecker/common.rs
@@ -1,14 +1,14 @@
 use ditto_ast::{Name, Type};
 use ditto_cst as cst;
-use std::collections::HashSet;
+use indexmap::IndexSet;
 
-pub fn type_variables(ast_type: &Type) -> HashSet<usize> {
-    let mut accum = HashSet::new();
+pub fn type_variables(ast_type: &Type) -> IndexSet<usize> {
+    let mut accum = IndexSet::new();
     type_variables_rec(ast_type, &mut accum);
     accum
 }
 
-fn type_variables_rec(ast_type: &Type, accum: &mut HashSet<usize>) {
+fn type_variables_rec(ast_type: &Type, accum: &mut IndexSet<usize>) {
     use Type::*;
     match ast_type {
         Call {
@@ -43,22 +43,18 @@ fn type_variables_rec(ast_type: &Type, accum: &mut HashSet<usize>) {
                 type_variables_rec(t, accum);
             }
         }
-        ConstructorAlias {
-            alias_variables, ..
-        } => {
-            accum.extend(alias_variables);
-        }
+        ConstructorAlias { aliased_type, .. } => type_variables_rec(aliased_type, accum),
         Constructor { .. } | PrimConstructor { .. } => {}
     }
 }
 
-pub fn cst_type_variables(t: &cst::Type) -> HashSet<Name> {
-    let mut accum = HashSet::new();
+pub fn cst_type_variables(t: &cst::Type) -> IndexSet<Name> {
+    let mut accum = IndexSet::new();
     cst_type_variables_rec(t, &mut accum);
     accum
 }
 
-fn cst_type_variables_rec(t: &cst::Type, accum: &mut HashSet<Name>) {
+fn cst_type_variables_rec(t: &cst::Type, accum: &mut IndexSet<Name>) {
     use cst::Type::*;
     match t {
         Parens(parens) => cst_type_variables_rec(&parens.value, accum),
@@ -151,13 +147,13 @@ mod test_macros {
     macro_rules! identity_scheme {
         ($name:expr) => {
             Scheme {
-                forall: std::collections::HashSet::from_iter(vec![0]),
+                forall: indexmap::IndexSet::from_iter(vec![0]),
                 signature: $crate::typechecker::common::identity_type!($name),
             }
         };
         () => {
             Scheme {
-                forall: std::collections::HashSet::from_iter(vec![0]),
+                forall: indexmap::IndexSet::from_iter(vec![0]),
                 signature: $crate::typechecker::common::identity_type!(),
             }
         };

--- a/crates/ditto-checker/src/typechecker/env.rs
+++ b/crates/ditto-checker/src/typechecker/env.rs
@@ -4,10 +4,8 @@ use ditto_ast::{
     Expression, FullyQualifiedName, FullyQualifiedProperName, Name, Pattern, ProperName,
     QualifiedName, QualifiedProperName, Span, Type,
 };
-use std::{
-    collections::{HashMap, HashSet},
-    default::Default,
-};
+use indexmap::IndexSet;
+use std::{collections::HashMap, default::Default};
 
 #[derive(Default, Clone)]
 pub struct Env {
@@ -32,7 +30,7 @@ impl Env {
             signature: ast_type,
         }
     }
-    fn free_type_variables(&self) -> HashSet<usize> {
+    fn free_type_variables(&self) -> IndexSet<usize> {
         self.constructors
             .values()
             .map(|env_constructor| env_constructor.get_scheme().free_type_variables())

--- a/crates/ditto-checker/src/typechecker/mod.rs
+++ b/crates/ditto-checker/src/typechecker/mod.rs
@@ -25,8 +25,8 @@ use ditto_ast::{
     QualifiedName, Row, Span, Type,
 };
 use ditto_cst as cst;
-use indexmap::IndexMap;
-use std::collections::{HashMap, HashSet};
+use indexmap::{IndexMap, IndexSet};
+use std::collections::HashMap;
 
 #[cfg(test)]
 pub fn typecheck(
@@ -1137,7 +1137,7 @@ fn with_extended_env<T>(
             EnvValue::ModuleValue {
                 span,
                 variable_scheme: Scheme {
-                    forall: HashSet::new(),
+                    forall: IndexSet::new(),
                     signature: value_type,
                 },
                 variable: unqualified_name.value,

--- a/crates/ditto-checker/src/typechecker/pre_ast.rs
+++ b/crates/ditto-checker/src/typechecker/pre_ast.rs
@@ -550,6 +550,9 @@ pub fn check_type_annotation(
     type_annotation: cst::TypeAnnotation,
 ) -> Result<Type> {
     let cst_type = type_annotation.1;
+
+    // WARNING: we are inadvertently depending on the order of these type variables,
+    // hence why we use an `IndexSet`. This should be fixed.
     for name in cst_type_variables(&cst_type) {
         if let hash_map::Entry::Vacant(e) = env_type_variables.entry(name) {
             let (var, variable_kind) = state.supply.fresh_kind();

--- a/crates/ditto-checker/src/typechecker/scheme.rs
+++ b/crates/ditto-checker/src/typechecker/scheme.rs
@@ -1,6 +1,7 @@
 use super::{common::type_variables, Substitution};
 use crate::supply::Supply;
 use ditto_ast::Type;
+use indexmap::IndexSet;
 use std::collections::HashSet;
 
 /// A polymorphic type.
@@ -9,7 +10,7 @@ use std::collections::HashSet;
 #[derive(Debug, Clone)]
 pub struct Scheme {
     /// The "quantifier".
-    pub forall: HashSet<usize>,
+    pub forall: IndexSet<usize>,
     /// The enclosed type.
     pub signature: Type,
 }

--- a/crates/ditto-checker/tests/cmd/basic_task_module/test.stdin
+++ b/crates/ditto-checker/tests/cmd/basic_task_module/test.stdin
@@ -1,0 +1,17 @@
+module Task exports (
+    Task,
+    succeed,
+);
+
+
+type alias VoidEffect = Effect(Unit);
+
+type Result(a, e) =
+    | Ok(a)
+    | Err(e);
+
+type alias Callback(a, e) = (Result(a, e)) -> VoidEffect;
+
+type Task(a, e) = Task((Callback(a, e)) -> VoidEffect);
+
+succeed = fn (a): Task(a, e) -> Task(fn (callback) -> callback(Ok(a)));

--- a/crates/ditto-checker/tests/cmd/basic_task_module/test.stdout
+++ b/crates/ditto-checker/tests/cmd/basic_task_module/test.stdout
@@ -1,0 +1,1674 @@
+{
+  "module_name": [
+    "Task"
+  ],
+  "exports": {
+    "types": {
+      "Task": {
+        "Type": {
+          "doc_comments": [],
+          "doc_position": 0,
+          "kind": {
+            "Function": {
+              "parameters": [
+                "Type",
+                "Type"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "constructors": {},
+    "values": {
+      "succeed": {
+        "doc_comments": [],
+        "doc_position": 1,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "Variable",
+                "data": {
+                  "variable_kind": "Type",
+                  "var": 0,
+                  "source_name": "a"
+                }
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          "Type",
+                          "Type"
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Task"
+                        ]
+                      ],
+                      "value": "Task"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Task"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": "Type",
+                      "var": 0,
+                      "source_name": "a"
+                    }
+                  },
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": "Type",
+                      "var": 2,
+                      "source_name": "e"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "types": {
+    "Result": {
+      "Type": {
+        "doc_comments": [],
+        "type_name_span": {
+          "start_offset": 94,
+          "end_offset": 100
+        },
+        "kind": {
+          "Function": {
+            "parameters": [
+              "Type",
+              "Type"
+            ]
+          }
+        }
+      }
+    },
+    "VoidEffect": {
+      "Alias": {
+        "doc_comments": [],
+        "type_name_span": {
+          "start_offset": 61,
+          "end_offset": 71
+        },
+        "kind": "Type",
+        "aliased_type": {
+          "type": "Call",
+          "data": {
+            "function": {
+              "type": "PrimConstructor",
+              "data": "Effect"
+            },
+            "arguments": [
+              {
+                "type": "PrimConstructor",
+                "data": "Unit"
+              }
+            ]
+          }
+        },
+        "alias_variables": []
+      }
+    },
+    "Callback": {
+      "Alias": {
+        "doc_comments": [],
+        "type_name_span": {
+          "start_offset": 147,
+          "end_offset": 155
+        },
+        "kind": {
+          "Function": {
+            "parameters": [
+              "Type",
+              "Type"
+            ]
+          }
+        },
+        "aliased_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "Constructor",
+                    "data": {
+                      "constructor_kind": {
+                        "Function": {
+                          "parameters": [
+                            "Type",
+                            "Type"
+                          ]
+                        }
+                      },
+                      "canonical_value": {
+                        "module_name": [
+                          null,
+                          [
+                            "Task"
+                          ]
+                        ],
+                        "value": "Result"
+                      },
+                      "source_value": {
+                        "module_name": null,
+                        "value": "Result"
+                      }
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "Variable",
+                      "data": {
+                        "variable_kind": "Type",
+                        "var": 0,
+                        "source_name": "a"
+                      }
+                    },
+                    {
+                      "type": "Variable",
+                      "data": {
+                        "variable_kind": "Type",
+                        "var": 2,
+                        "source_name": "e"
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "return_type": {
+              "type": "ConstructorAlias",
+              "data": {
+                "constructor_kind": "Type",
+                "canonical_value": {
+                  "module_name": [
+                    null,
+                    [
+                      "Task"
+                    ]
+                  ],
+                  "value": "VoidEffect"
+                },
+                "source_value": {
+                  "module_name": null,
+                  "value": "VoidEffect"
+                },
+                "alias_variables": [],
+                "aliased_type": {
+                  "type": "Call",
+                  "data": {
+                    "function": {
+                      "type": "PrimConstructor",
+                      "data": "Effect"
+                    },
+                    "arguments": [
+                      {
+                        "type": "PrimConstructor",
+                        "data": "Unit"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "alias_variables": [
+          0,
+          2
+        ]
+      }
+    },
+    "Task": {
+      "Type": {
+        "doc_comments": [],
+        "type_name_span": {
+          "start_offset": 200,
+          "end_offset": 204
+        },
+        "kind": {
+          "Function": {
+            "parameters": [
+              "Type",
+              "Type"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "constructors": {
+    "Ok": {
+      "doc_comments": [],
+      "doc_position": 0,
+      "constructor_name_span": {
+        "start_offset": 115,
+        "end_offset": 117
+      },
+      "fields": [
+        {
+          "type": "Variable",
+          "data": {
+            "variable_kind": "Type",
+            "var": 0,
+            "source_name": "a"
+          }
+        }
+      ],
+      "return_type": {
+        "type": "Call",
+        "data": {
+          "function": {
+            "type": "Constructor",
+            "data": {
+              "constructor_kind": {
+                "Function": {
+                  "parameters": [
+                    "Type",
+                    "Type"
+                  ]
+                }
+              },
+              "canonical_value": {
+                "module_name": [
+                  null,
+                  [
+                    "Task"
+                  ]
+                ],
+                "value": "Result"
+              },
+              "source_value": {
+                "module_name": null,
+                "value": "Result"
+              }
+            }
+          },
+          "arguments": [
+            {
+              "type": "Variable",
+              "data": {
+                "variable_kind": "Type",
+                "var": 0,
+                "source_name": "a"
+              }
+            },
+            {
+              "type": "Variable",
+              "data": {
+                "variable_kind": "Type",
+                "var": 2,
+                "source_name": "e"
+              }
+            }
+          ]
+        }
+      },
+      "return_type_name": "Result"
+    },
+    "Err": {
+      "doc_comments": [],
+      "doc_position": 1,
+      "constructor_name_span": {
+        "start_offset": 127,
+        "end_offset": 130
+      },
+      "fields": [
+        {
+          "type": "Variable",
+          "data": {
+            "variable_kind": "Type",
+            "var": 2,
+            "source_name": "e"
+          }
+        }
+      ],
+      "return_type": {
+        "type": "Call",
+        "data": {
+          "function": {
+            "type": "Constructor",
+            "data": {
+              "constructor_kind": {
+                "Function": {
+                  "parameters": [
+                    "Type",
+                    "Type"
+                  ]
+                }
+              },
+              "canonical_value": {
+                "module_name": [
+                  null,
+                  [
+                    "Task"
+                  ]
+                ],
+                "value": "Result"
+              },
+              "source_value": {
+                "module_name": null,
+                "value": "Result"
+              }
+            }
+          },
+          "arguments": [
+            {
+              "type": "Variable",
+              "data": {
+                "variable_kind": "Type",
+                "var": 0,
+                "source_name": "a"
+              }
+            },
+            {
+              "type": "Variable",
+              "data": {
+                "variable_kind": "Type",
+                "var": 2,
+                "source_name": "e"
+              }
+            }
+          ]
+        }
+      },
+      "return_type_name": "Result"
+    },
+    "Task": {
+      "doc_comments": [],
+      "doc_position": 0,
+      "constructor_name_span": {
+        "start_offset": 213,
+        "end_offset": 217
+      },
+      "fields": [
+        {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "ConstructorAlias",
+                    "data": {
+                      "constructor_kind": {
+                        "Function": {
+                          "parameters": [
+                            "Type",
+                            "Type"
+                          ]
+                        }
+                      },
+                      "canonical_value": {
+                        "module_name": [
+                          null,
+                          [
+                            "Task"
+                          ]
+                        ],
+                        "value": "Callback"
+                      },
+                      "source_value": {
+                        "module_name": null,
+                        "value": "Callback"
+                      },
+                      "alias_variables": [
+                        0,
+                        2
+                      ],
+                      "aliased_type": {
+                        "type": "Function",
+                        "data": {
+                          "parameters": [
+                            {
+                              "type": "Call",
+                              "data": {
+                                "function": {
+                                  "type": "Constructor",
+                                  "data": {
+                                    "constructor_kind": {
+                                      "Function": {
+                                        "parameters": [
+                                          "Type",
+                                          "Type"
+                                        ]
+                                      }
+                                    },
+                                    "canonical_value": {
+                                      "module_name": [
+                                        null,
+                                        [
+                                          "Task"
+                                        ]
+                                      ],
+                                      "value": "Result"
+                                    },
+                                    "source_value": {
+                                      "module_name": null,
+                                      "value": "Result"
+                                    }
+                                  }
+                                },
+                                "arguments": [
+                                  {
+                                    "type": "Variable",
+                                    "data": {
+                                      "variable_kind": "Type",
+                                      "var": 0,
+                                      "source_name": "a"
+                                    }
+                                  },
+                                  {
+                                    "type": "Variable",
+                                    "data": {
+                                      "variable_kind": "Type",
+                                      "var": 2,
+                                      "source_name": "e"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "return_type": {
+                            "type": "ConstructorAlias",
+                            "data": {
+                              "constructor_kind": "Type",
+                              "canonical_value": {
+                                "module_name": [
+                                  null,
+                                  [
+                                    "Task"
+                                  ]
+                                ],
+                                "value": "VoidEffect"
+                              },
+                              "source_value": {
+                                "module_name": null,
+                                "value": "VoidEffect"
+                              },
+                              "alias_variables": [],
+                              "aliased_type": {
+                                "type": "Call",
+                                "data": {
+                                  "function": {
+                                    "type": "PrimConstructor",
+                                    "data": "Effect"
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "PrimConstructor",
+                                      "data": "Unit"
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "Variable",
+                      "data": {
+                        "variable_kind": "Type",
+                        "var": 0,
+                        "source_name": "a"
+                      }
+                    },
+                    {
+                      "type": "Variable",
+                      "data": {
+                        "variable_kind": "Type",
+                        "var": 2,
+                        "source_name": "e"
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "return_type": {
+              "type": "ConstructorAlias",
+              "data": {
+                "constructor_kind": "Type",
+                "canonical_value": {
+                  "module_name": [
+                    null,
+                    [
+                      "Task"
+                    ]
+                  ],
+                  "value": "VoidEffect"
+                },
+                "source_value": {
+                  "module_name": null,
+                  "value": "VoidEffect"
+                },
+                "alias_variables": [],
+                "aliased_type": {
+                  "type": "Call",
+                  "data": {
+                    "function": {
+                      "type": "PrimConstructor",
+                      "data": "Effect"
+                    },
+                    "arguments": [
+                      {
+                        "type": "PrimConstructor",
+                        "data": "Unit"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "return_type": {
+        "type": "Call",
+        "data": {
+          "function": {
+            "type": "Constructor",
+            "data": {
+              "constructor_kind": {
+                "Function": {
+                  "parameters": [
+                    "Type",
+                    "Type"
+                  ]
+                }
+              },
+              "canonical_value": {
+                "module_name": [
+                  null,
+                  [
+                    "Task"
+                  ]
+                ],
+                "value": "Task"
+              },
+              "source_value": {
+                "module_name": null,
+                "value": "Task"
+              }
+            }
+          },
+          "arguments": [
+            {
+              "type": "Variable",
+              "data": {
+                "variable_kind": "Type",
+                "var": 0,
+                "source_name": "a"
+              }
+            },
+            {
+              "type": "Variable",
+              "data": {
+                "variable_kind": "Type",
+                "var": 2,
+                "source_name": "e"
+              }
+            }
+          ]
+        }
+      },
+      "return_type_name": "Task"
+    }
+  },
+  "values": {
+    "succeed": {
+      "doc_comments": [],
+      "name_span": {
+        "start_offset": 252,
+        "end_offset": 259
+      },
+      "expression": {
+        "expression": "Function",
+        "data": {
+          "span": {
+            "start_offset": 262,
+            "end_offset": 322
+          },
+          "function_type": {
+            "type": "Function",
+            "data": {
+              "parameters": [
+                {
+                  "type": "Variable",
+                  "data": {
+                    "variable_kind": "Type",
+                    "var": 0,
+                    "source_name": "a"
+                  }
+                }
+              ],
+              "return_type": {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "Constructor",
+                    "data": {
+                      "constructor_kind": {
+                        "Function": {
+                          "parameters": [
+                            "Type",
+                            "Type"
+                          ]
+                        }
+                      },
+                      "canonical_value": {
+                        "module_name": [
+                          null,
+                          [
+                            "Task"
+                          ]
+                        ],
+                        "value": "Task"
+                      },
+                      "source_value": {
+                        "module_name": null,
+                        "value": "Task"
+                      }
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "Variable",
+                      "data": {
+                        "variable_kind": "Type",
+                        "var": 0,
+                        "source_name": "a"
+                      }
+                    },
+                    {
+                      "type": "Variable",
+                      "data": {
+                        "variable_kind": "Type",
+                        "var": 2,
+                        "source_name": "e"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "binders": [
+            [
+              {
+                "Variable": {
+                  "span": {
+                    "start_offset": 266,
+                    "end_offset": 267
+                  },
+                  "name": "a"
+                }
+              },
+              {
+                "type": "Variable",
+                "data": {
+                  "variable_kind": "Type",
+                  "var": 0,
+                  "source_name": "a"
+                }
+              }
+            ]
+          ],
+          "body": {
+            "expression": "Call",
+            "data": {
+              "span": {
+                "start_offset": 284,
+                "end_offset": 322
+              },
+              "call_type": {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "Constructor",
+                    "data": {
+                      "constructor_kind": {
+                        "Function": {
+                          "parameters": [
+                            "Type",
+                            "Type"
+                          ]
+                        }
+                      },
+                      "canonical_value": {
+                        "module_name": [
+                          null,
+                          [
+                            "Task"
+                          ]
+                        ],
+                        "value": "Task"
+                      },
+                      "source_value": {
+                        "module_name": null,
+                        "value": "Task"
+                      }
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "Variable",
+                      "data": {
+                        "variable_kind": "Type",
+                        "var": 0,
+                        "source_name": "a"
+                      }
+                    },
+                    {
+                      "type": "Variable",
+                      "data": {
+                        "variable_kind": "Type",
+                        "var": 2,
+                        "source_name": "e"
+                      }
+                    }
+                  ]
+                }
+              },
+              "function": {
+                "expression": "LocalConstructor",
+                "data": {
+                  "span": {
+                    "start_offset": 284,
+                    "end_offset": 288
+                  },
+                  "constructor_type": {
+                    "type": "Function",
+                    "data": {
+                      "parameters": [
+                        {
+                          "type": "Function",
+                          "data": {
+                            "parameters": [
+                              {
+                                "type": "Call",
+                                "data": {
+                                  "function": {
+                                    "type": "ConstructorAlias",
+                                    "data": {
+                                      "constructor_kind": {
+                                        "Function": {
+                                          "parameters": [
+                                            "Type",
+                                            "Type"
+                                          ]
+                                        }
+                                      },
+                                      "canonical_value": {
+                                        "module_name": [
+                                          null,
+                                          [
+                                            "Task"
+                                          ]
+                                        ],
+                                        "value": "Callback"
+                                      },
+                                      "source_value": {
+                                        "module_name": null,
+                                        "value": "Callback"
+                                      },
+                                      "alias_variables": [
+                                        0,
+                                        2
+                                      ],
+                                      "aliased_type": {
+                                        "type": "Function",
+                                        "data": {
+                                          "parameters": [
+                                            {
+                                              "type": "Call",
+                                              "data": {
+                                                "function": {
+                                                  "type": "Constructor",
+                                                  "data": {
+                                                    "constructor_kind": {
+                                                      "Function": {
+                                                        "parameters": [
+                                                          "Type",
+                                                          "Type"
+                                                        ]
+                                                      }
+                                                    },
+                                                    "canonical_value": {
+                                                      "module_name": [
+                                                        null,
+                                                        [
+                                                          "Task"
+                                                        ]
+                                                      ],
+                                                      "value": "Result"
+                                                    },
+                                                    "source_value": {
+                                                      "module_name": null,
+                                                      "value": "Result"
+                                                    }
+                                                  }
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "type": "Variable",
+                                                    "data": {
+                                                      "variable_kind": "Type",
+                                                      "var": 0,
+                                                      "source_name": "a"
+                                                    }
+                                                  },
+                                                  {
+                                                    "type": "Variable",
+                                                    "data": {
+                                                      "variable_kind": "Type",
+                                                      "var": 2,
+                                                      "source_name": "e"
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ],
+                                          "return_type": {
+                                            "type": "ConstructorAlias",
+                                            "data": {
+                                              "constructor_kind": "Type",
+                                              "canonical_value": {
+                                                "module_name": [
+                                                  null,
+                                                  [
+                                                    "Task"
+                                                  ]
+                                                ],
+                                                "value": "VoidEffect"
+                                              },
+                                              "source_value": {
+                                                "module_name": null,
+                                                "value": "VoidEffect"
+                                              },
+                                              "alias_variables": [],
+                                              "aliased_type": {
+                                                "type": "Call",
+                                                "data": {
+                                                  "function": {
+                                                    "type": "PrimConstructor",
+                                                    "data": "Effect"
+                                                  },
+                                                  "arguments": [
+                                                    {
+                                                      "type": "PrimConstructor",
+                                                      "data": "Unit"
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "Variable",
+                                      "data": {
+                                        "variable_kind": "Type",
+                                        "var": 0,
+                                        "source_name": "a"
+                                      }
+                                    },
+                                    {
+                                      "type": "Variable",
+                                      "data": {
+                                        "variable_kind": "Type",
+                                        "var": 2,
+                                        "source_name": "e"
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "return_type": {
+                              "type": "ConstructorAlias",
+                              "data": {
+                                "constructor_kind": "Type",
+                                "canonical_value": {
+                                  "module_name": [
+                                    null,
+                                    [
+                                      "Task"
+                                    ]
+                                  ],
+                                  "value": "VoidEffect"
+                                },
+                                "source_value": {
+                                  "module_name": null,
+                                  "value": "VoidEffect"
+                                },
+                                "alias_variables": [],
+                                "aliased_type": {
+                                  "type": "Call",
+                                  "data": {
+                                    "function": {
+                                      "type": "PrimConstructor",
+                                      "data": "Effect"
+                                    },
+                                    "arguments": [
+                                      {
+                                        "type": "PrimConstructor",
+                                        "data": "Unit"
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "return_type": {
+                        "type": "Call",
+                        "data": {
+                          "function": {
+                            "type": "Constructor",
+                            "data": {
+                              "constructor_kind": {
+                                "Function": {
+                                  "parameters": [
+                                    "Type",
+                                    "Type"
+                                  ]
+                                }
+                              },
+                              "canonical_value": {
+                                "module_name": [
+                                  null,
+                                  [
+                                    "Task"
+                                  ]
+                                ],
+                                "value": "Task"
+                              },
+                              "source_value": {
+                                "module_name": null,
+                                "value": "Task"
+                              }
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "type": "Variable",
+                              "data": {
+                                "variable_kind": "Type",
+                                "var": 0,
+                                "source_name": "a"
+                              }
+                            },
+                            {
+                              "type": "Variable",
+                              "data": {
+                                "variable_kind": "Type",
+                                "var": 2,
+                                "source_name": "e"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "constructor": "Task"
+                }
+              },
+              "arguments": [
+                {
+                  "Expression": {
+                    "expression": "Function",
+                    "data": {
+                      "span": {
+                        "start_offset": 289,
+                        "end_offset": 321
+                      },
+                      "function_type": {
+                        "type": "Function",
+                        "data": {
+                          "parameters": [
+                            {
+                              "type": "Call",
+                              "data": {
+                                "function": {
+                                  "type": "ConstructorAlias",
+                                  "data": {
+                                    "constructor_kind": {
+                                      "Function": {
+                                        "parameters": [
+                                          "Type",
+                                          "Type"
+                                        ]
+                                      }
+                                    },
+                                    "canonical_value": {
+                                      "module_name": [
+                                        null,
+                                        [
+                                          "Task"
+                                        ]
+                                      ],
+                                      "value": "Callback"
+                                    },
+                                    "source_value": {
+                                      "module_name": null,
+                                      "value": "Callback"
+                                    },
+                                    "alias_variables": [
+                                      0,
+                                      2
+                                    ],
+                                    "aliased_type": {
+                                      "type": "Function",
+                                      "data": {
+                                        "parameters": [
+                                          {
+                                            "type": "Call",
+                                            "data": {
+                                              "function": {
+                                                "type": "Constructor",
+                                                "data": {
+                                                  "constructor_kind": {
+                                                    "Function": {
+                                                      "parameters": [
+                                                        "Type",
+                                                        "Type"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "canonical_value": {
+                                                    "module_name": [
+                                                      null,
+                                                      [
+                                                        "Task"
+                                                      ]
+                                                    ],
+                                                    "value": "Result"
+                                                  },
+                                                  "source_value": {
+                                                    "module_name": null,
+                                                    "value": "Result"
+                                                  }
+                                                }
+                                              },
+                                              "arguments": [
+                                                {
+                                                  "type": "Variable",
+                                                  "data": {
+                                                    "variable_kind": "Type",
+                                                    "var": 0,
+                                                    "source_name": "a"
+                                                  }
+                                                },
+                                                {
+                                                  "type": "Variable",
+                                                  "data": {
+                                                    "variable_kind": "Type",
+                                                    "var": 2,
+                                                    "source_name": "e"
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ],
+                                        "return_type": {
+                                          "type": "ConstructorAlias",
+                                          "data": {
+                                            "constructor_kind": "Type",
+                                            "canonical_value": {
+                                              "module_name": [
+                                                null,
+                                                [
+                                                  "Task"
+                                                ]
+                                              ],
+                                              "value": "VoidEffect"
+                                            },
+                                            "source_value": {
+                                              "module_name": null,
+                                              "value": "VoidEffect"
+                                            },
+                                            "alias_variables": [],
+                                            "aliased_type": {
+                                              "type": "Call",
+                                              "data": {
+                                                "function": {
+                                                  "type": "PrimConstructor",
+                                                  "data": "Effect"
+                                                },
+                                                "arguments": [
+                                                  {
+                                                    "type": "PrimConstructor",
+                                                    "data": "Unit"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "arguments": [
+                                  {
+                                    "type": "Variable",
+                                    "data": {
+                                      "variable_kind": "Type",
+                                      "var": 0,
+                                      "source_name": "a"
+                                    }
+                                  },
+                                  {
+                                    "type": "Variable",
+                                    "data": {
+                                      "variable_kind": "Type",
+                                      "var": 2,
+                                      "source_name": "e"
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          ],
+                          "return_type": {
+                            "type": "ConstructorAlias",
+                            "data": {
+                              "constructor_kind": "Type",
+                              "canonical_value": {
+                                "module_name": [
+                                  null,
+                                  [
+                                    "Task"
+                                  ]
+                                ],
+                                "value": "VoidEffect"
+                              },
+                              "source_value": {
+                                "module_name": null,
+                                "value": "VoidEffect"
+                              },
+                              "alias_variables": [],
+                              "aliased_type": {
+                                "type": "Call",
+                                "data": {
+                                  "function": {
+                                    "type": "PrimConstructor",
+                                    "data": "Effect"
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "PrimConstructor",
+                                      "data": "Unit"
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "binders": [
+                        [
+                          {
+                            "Variable": {
+                              "span": {
+                                "start_offset": 293,
+                                "end_offset": 301
+                              },
+                              "name": "callback"
+                            }
+                          },
+                          {
+                            "type": "Function",
+                            "data": {
+                              "parameters": [
+                                {
+                                  "type": "Call",
+                                  "data": {
+                                    "function": {
+                                      "type": "Constructor",
+                                      "data": {
+                                        "constructor_kind": {
+                                          "Function": {
+                                            "parameters": [
+                                              "Type",
+                                              "Type"
+                                            ]
+                                          }
+                                        },
+                                        "canonical_value": {
+                                          "module_name": [
+                                            null,
+                                            [
+                                              "Task"
+                                            ]
+                                          ],
+                                          "value": "Result"
+                                        },
+                                        "source_value": {
+                                          "module_name": null,
+                                          "value": "Result"
+                                        }
+                                      }
+                                    },
+                                    "arguments": [
+                                      {
+                                        "type": "Variable",
+                                        "data": {
+                                          "variable_kind": "Type",
+                                          "var": 0,
+                                          "source_name": "a"
+                                        }
+                                      },
+                                      {
+                                        "type": "Variable",
+                                        "data": {
+                                          "variable_kind": "Type",
+                                          "var": 2,
+                                          "source_name": "e"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ],
+                              "return_type": {
+                                "type": "ConstructorAlias",
+                                "data": {
+                                  "constructor_kind": "Type",
+                                  "canonical_value": {
+                                    "module_name": [
+                                      null,
+                                      [
+                                        "Task"
+                                      ]
+                                    ],
+                                    "value": "VoidEffect"
+                                  },
+                                  "source_value": {
+                                    "module_name": null,
+                                    "value": "VoidEffect"
+                                  },
+                                  "alias_variables": [],
+                                  "aliased_type": {
+                                    "type": "Call",
+                                    "data": {
+                                      "function": {
+                                        "type": "PrimConstructor",
+                                        "data": "Effect"
+                                      },
+                                      "arguments": [
+                                        {
+                                          "type": "PrimConstructor",
+                                          "data": "Unit"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      ],
+                      "body": {
+                        "expression": "Call",
+                        "data": {
+                          "span": {
+                            "start_offset": 306,
+                            "end_offset": 321
+                          },
+                          "call_type": {
+                            "type": "ConstructorAlias",
+                            "data": {
+                              "constructor_kind": "Type",
+                              "canonical_value": {
+                                "module_name": [
+                                  null,
+                                  [
+                                    "Task"
+                                  ]
+                                ],
+                                "value": "VoidEffect"
+                              },
+                              "source_value": {
+                                "module_name": null,
+                                "value": "VoidEffect"
+                              },
+                              "alias_variables": [],
+                              "aliased_type": {
+                                "type": "Call",
+                                "data": {
+                                  "function": {
+                                    "type": "PrimConstructor",
+                                    "data": "Effect"
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "PrimConstructor",
+                                      "data": "Unit"
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "function": {
+                            "expression": "LocalVariable",
+                            "data": {
+                              "span": {
+                                "start_offset": 306,
+                                "end_offset": 314
+                              },
+                              "variable_type": {
+                                "type": "Function",
+                                "data": {
+                                  "parameters": [
+                                    {
+                                      "type": "Call",
+                                      "data": {
+                                        "function": {
+                                          "type": "Constructor",
+                                          "data": {
+                                            "constructor_kind": {
+                                              "Function": {
+                                                "parameters": [
+                                                  "Type",
+                                                  "Type"
+                                                ]
+                                              }
+                                            },
+                                            "canonical_value": {
+                                              "module_name": [
+                                                null,
+                                                [
+                                                  "Task"
+                                                ]
+                                              ],
+                                              "value": "Result"
+                                            },
+                                            "source_value": {
+                                              "module_name": null,
+                                              "value": "Result"
+                                            }
+                                          }
+                                        },
+                                        "arguments": [
+                                          {
+                                            "type": "Variable",
+                                            "data": {
+                                              "variable_kind": "Type",
+                                              "var": 0,
+                                              "source_name": "a"
+                                            }
+                                          },
+                                          {
+                                            "type": "Variable",
+                                            "data": {
+                                              "variable_kind": "Type",
+                                              "var": 2,
+                                              "source_name": "e"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ],
+                                  "return_type": {
+                                    "type": "ConstructorAlias",
+                                    "data": {
+                                      "constructor_kind": "Type",
+                                      "canonical_value": {
+                                        "module_name": [
+                                          null,
+                                          [
+                                            "Task"
+                                          ]
+                                        ],
+                                        "value": "VoidEffect"
+                                      },
+                                      "source_value": {
+                                        "module_name": null,
+                                        "value": "VoidEffect"
+                                      },
+                                      "alias_variables": [],
+                                      "aliased_type": {
+                                        "type": "Call",
+                                        "data": {
+                                          "function": {
+                                            "type": "PrimConstructor",
+                                            "data": "Effect"
+                                          },
+                                          "arguments": [
+                                            {
+                                              "type": "PrimConstructor",
+                                              "data": "Unit"
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "variable": "callback"
+                            }
+                          },
+                          "arguments": [
+                            {
+                              "Expression": {
+                                "expression": "Call",
+                                "data": {
+                                  "span": {
+                                    "start_offset": 315,
+                                    "end_offset": 320
+                                  },
+                                  "call_type": {
+                                    "type": "Call",
+                                    "data": {
+                                      "function": {
+                                        "type": "Constructor",
+                                        "data": {
+                                          "constructor_kind": {
+                                            "Function": {
+                                              "parameters": [
+                                                "Type",
+                                                "Type"
+                                              ]
+                                            }
+                                          },
+                                          "canonical_value": {
+                                            "module_name": [
+                                              null,
+                                              [
+                                                "Task"
+                                              ]
+                                            ],
+                                            "value": "Result"
+                                          },
+                                          "source_value": {
+                                            "module_name": null,
+                                            "value": "Result"
+                                          }
+                                        }
+                                      },
+                                      "arguments": [
+                                        {
+                                          "type": "Variable",
+                                          "data": {
+                                            "variable_kind": "Type",
+                                            "var": 0,
+                                            "source_name": "a"
+                                          }
+                                        },
+                                        {
+                                          "type": "Variable",
+                                          "data": {
+                                            "variable_kind": "Type",
+                                            "var": 2,
+                                            "source_name": "e"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "function": {
+                                    "expression": "LocalConstructor",
+                                    "data": {
+                                      "span": {
+                                        "start_offset": 315,
+                                        "end_offset": 317
+                                      },
+                                      "constructor_type": {
+                                        "type": "Function",
+                                        "data": {
+                                          "parameters": [
+                                            {
+                                              "type": "Variable",
+                                              "data": {
+                                                "variable_kind": "Type",
+                                                "var": 0,
+                                                "source_name": "a"
+                                              }
+                                            }
+                                          ],
+                                          "return_type": {
+                                            "type": "Call",
+                                            "data": {
+                                              "function": {
+                                                "type": "Constructor",
+                                                "data": {
+                                                  "constructor_kind": {
+                                                    "Function": {
+                                                      "parameters": [
+                                                        "Type",
+                                                        "Type"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "canonical_value": {
+                                                    "module_name": [
+                                                      null,
+                                                      [
+                                                        "Task"
+                                                      ]
+                                                    ],
+                                                    "value": "Result"
+                                                  },
+                                                  "source_value": {
+                                                    "module_name": null,
+                                                    "value": "Result"
+                                                  }
+                                                }
+                                              },
+                                              "arguments": [
+                                                {
+                                                  "type": "Variable",
+                                                  "data": {
+                                                    "variable_kind": "Type",
+                                                    "var": 0,
+                                                    "source_name": "a"
+                                                  }
+                                                },
+                                                {
+                                                  "type": "Variable",
+                                                  "data": {
+                                                    "variable_kind": "Type",
+                                                    "var": 2,
+                                                    "source_name": "e"
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "constructor": "Ok"
+                                    }
+                                  },
+                                  "arguments": [
+                                    {
+                                      "Expression": {
+                                        "expression": "LocalVariable",
+                                        "data": {
+                                          "span": {
+                                            "start_offset": 318,
+                                            "end_offset": 319
+                                          },
+                                          "variable_type": {
+                                            "type": "Variable",
+                                            "data": {
+                                              "variable_kind": "Type",
+                                              "var": 0,
+                                              "source_name": "a"
+                                            }
+                                          },
+                                          "variable": "a"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "values_toposort": [
+    "succeed"
+  ]
+}

--- a/crates/ditto-checker/tests/cmd/basic_task_module/test.toml
+++ b/crates/ditto-checker/tests/cmd/basic_task_module/test.toml
@@ -1,0 +1,3 @@
+bin.name = "ditto-checker-testbin-check-module"
+args = ["basic_task_module.ditto"]
+fs.sandbox = true


### PR DESCRIPTION
This fixes quite a nasty bug I encountered into where an infinite substitution was being generated when `forall` type variables were processed in a certain order...

Swapping out `HashSet` for `IndexSet` (to preserve insertion order) is of course not really a fix at all, as we shouldn't depend on insertion order. But fixing that will require a significant review of the type checking logic, which I don't want to be blocked on right now.