### PR TITLE
Fix required ditto version checking

### DIFF
--- a/crates/ditto-make/src/build_ninja.rs
+++ b/crates/ditto-make/src/build_ninja.rs
@@ -220,10 +220,15 @@ fn prepare_build_graph(
 
         // Check ditto version requirement
         if let Some(required_ditto_version) = config.required_ditto_version {
-            if !required_ditto_version.matches(ditto_version) {
+            let version = semver::Version {
+                pre: Default::default(),
+                build: Default::default(),
+                ..ditto_version.clone()
+            };
+            if !required_ditto_version.matches(&version) {
                 bail!(
                     "ditto version requirement not met for {}: current version = {}, wanted = {}",
-                    package_name.map_or("current_package".into(), |package_name| format!(
+                    package_name.map_or("current package".into(), |package_name| format!(
                         "{:?}",
                         package_name
                     )),

--- a/crates/ditto-make/tests/cmd/unsupported-ditto-version/test.stderr
+++ b/crates/ditto-make/tests/cmd/unsupported-ditto-version/test.stderr
@@ -1,4 +1,4 @@
 
-  × ditto version requirement not met for current_package: current version =
+  × ditto version requirement not met for current package: current version =
   │ 0.0.0-test, wanted = ^1.0.0
 


### PR DESCRIPTION
I tried adding a required ditto version to https://github.com/ditto-lang/std

```diff
diff --git a/ditto.toml b/ditto.toml
index 835b5b2..691be46 100644
--- a/ditto.toml
+++ b/ditto.toml
@@ -1,5 +1,6 @@
 name = "std"
 targets = ["web", "nodejs"]
+ditto-version = ">=0.0.2"
```

But that complained with:

```
  × error generating build.ninja
  ╰─▶ ditto version requirement not met for current_package: current version = 0.0.2-1-g2ea38ab, wanted = >=0.0.2
```

Maybe there's a way to specify in the requirement that `pre` should be ignored, but I also think `ditto-version = ">=0.0.2"` should just work. This PR makes it so.

_(I also took the underscore out of `current_package` while I was there)_