### PR TITLE
Ensure that multiline strings and escapes work as expected

### DIFF
--- a/crates/ditto-codegen-js/src/render.rs
+++ b/crates/ditto-codegen-js/src/render.rs
@@ -203,7 +203,7 @@ impl Render for Expression {
             }
             Self::String(inner_string) => {
                 accum.push('"');
-                accum.push_str(inner_string);
+                accum.push_str(&inner_string.replace('\n', "\\n"));
                 accum.push('"');
             }
             Self::True => {

--- a/crates/ditto-codegen-js/tests/golden/strings.ditto
+++ b/crates/ditto-codegen-js/tests/golden/strings.ditto
@@ -1,0 +1,10 @@
+module Test exports (..)
+
+
+escapes = "\t\n"
+
+multi_line = "
+test
+"
+
+escaped_quotes = "\"\""

--- a/crates/ditto-codegen-js/tests/golden/strings.js
+++ b/crates/ditto-codegen-js/tests/golden/strings.js
@@ -1,0 +1,4 @@
+const escaped_quotes = '""';
+const multi_line = "\ntest\n";
+const escapes = "\t\n";
+export { escaped_quotes, escapes, multi_line };

--- a/crates/ditto-cst/src/lexer.rs
+++ b/crates/ditto-cst/src/lexer.rs
@@ -280,8 +280,8 @@ enum RawToken {
     #[regex(r"\d[\d_]*(?:\.\d[\d_]*)?", callback = |lex| lex.slice().parse())]
     Number(String),
 
-    // TODO: improve this regex
-    #[regex(r#""[^"]*""#, callback = |lex| lex.slice().parse())]
+    // Regex credit: https://stackoverflow.com/a/10786066
+    #[regex(r#""([^"\\]*(\\.[^"\\]*)*)""#, callback = |lex| lex.slice().parse())]
     String(String),
 
     #[regex(r"\r?\n")]


### PR DESCRIPTION
Check that some fancier features of string literals work as expected.

This is in anticipation of #65 :eyes: 