### PR TITLE
Add JavaScript package manager configuration option 📦 

### DIFF
--- a/crates/ditto-config/src/lib.rs
+++ b/crates/ditto-config/src/lib.rs
@@ -159,6 +159,26 @@ pub struct CodegenJsConfig {
     /// package is built as a dependency.
     #[serde(rename = "package-json")]
     pub package_json_additions: Option<serde_json::Map<String, serde_json::Value>>,
+    /// Package manager being used. This affects the format of generated `package.json` files.
+    #[serde(rename = "package-manager", default)]
+    pub package_manager: PackageManager,
+}
+
+/// Flavours of JavaScript package management.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum PackageManager {
+    /// The standard package manager shipped with NodeJS.
+    #[serde(rename = "npm")]
+    Npm,
+    /// https://pnpm.io/
+    #[serde(rename = "pnpm")]
+    Pnpm,
+}
+
+impl Default for PackageManager {
+    fn default() -> Self {
+        Self::Npm
+    }
 }
 
 impl Default for CodegenJsConfig {
@@ -167,6 +187,7 @@ impl Default for CodegenJsConfig {
             dist_dir: default_js_dist_dir(),
             packages_dir: default_js_packages_dir(),
             package_json_additions: None,
+            package_manager: PackageManager::Npm,
         }
     }
 }

--- a/crates/ditto-config/src/tests.rs
+++ b/crates/ditto-config/src/tests.rs
@@ -153,6 +153,39 @@ mod successes {
             }
         );
     }
+
+    #[test]
+    fn it_parses_js_package_manager() {
+        use crate::PackageManager::*;
+        assert_parses!(
+            r#"
+            name = "test"
+            targets = []
+            [codegen-js]
+            package-manager = "pnpm"
+        "#,
+            Config {
+                codegen_js_config: CodegenJsConfig {
+                    package_manager: Pnpm,
+                    ..
+                },
+                ..
+            }
+        );
+        assert_parses!(
+            r#"
+            name = "test"
+            targets = []
+        "#,
+            Config {
+                codegen_js_config: CodegenJsConfig {
+                    package_manager: Npm, // default
+                    ..
+                },
+                ..
+            }
+        );
+    }
 }
 
 mod errors {

--- a/crates/ditto-make/README.md
+++ b/crates/ditto-make/README.md
@@ -56,12 +56,13 @@ Options:
 <!-- prettier-ignore-start -->
 ```console
 $ ditto compile package-json --help
-Usage: ditto compile package-json -i <input> -o <output>
+Usage: ditto compile package-json -i <input> -o <output> --package-manager <PKG_MANAGER>
 
 Options:
-  -i <input>       
-  -o <output>      
-  -h, --help       Print help information
+  -i <input>                           
+  -o <output>                          
+      --package-manager <PKG_MANAGER>  [possible values: npm, pnpm]
+  -h, --help                           Print help information
 
 ```
 <!-- prettier-ignore-end -->

--- a/crates/ditto-make/src/build_ninja.rs
+++ b/crates/ditto-make/src/build_ninja.rs
@@ -510,7 +510,7 @@ impl Rule {
         let ditto = ditto_bin.to_string_lossy();
         Self {
             name: RULE_NAME_PACKAGE_JSON.to_string(),
-            command: format!("{ditto} {compile} {package_json} -{i} ${{in}} -{o} ${{out}}"),
+            command: format!("{ditto} {compile} {package_json} -{i} ${{in}} -{o} ${{out}} --package-manager ${{package-manager}}"),
         }
     }
 
@@ -590,10 +590,13 @@ impl Build {
             outputs,
             rule_name: String::from(RULE_NAME_PACKAGE_JSON),
             inputs,
-            variables: HashMap::from_iter(vec![(
-                String::from("description"),
-                format!("Generating package.json for {}", package_name.as_str()),
-            )]),
+            variables: HashMap::from_iter(vec![
+                (String::from("package-manager"), "pnpm".to_string()),
+                (
+                    String::from("description"),
+                    format!("Generating package.json for {}", package_name.as_str()),
+                ),
+            ]),
         }
     }
 

--- a/crates/ditto-make/tests/cmd/all-good/test.stdout
+++ b/crates/ditto-make/tests/cmd/all-good/test.stdout
@@ -7,7 +7,7 @@ rule js
   command = ditto compile js -i ${in} -o ${out}
 
 rule package_json
-  command = ditto compile package-json -i ${in} -o ${out}
+  command = ditto compile package-json -i ${in} -o ${out} --package-manager ${package-manager}
 
 build builddir/A.ast builddir/A.ast-exports builddir/A.checker-warnings: ast ./ditto-src/A.ditto
   description = Checking A
@@ -53,5 +53,6 @@ build packages/dep/Util.js: js builddir/dep/Util.ast
 
 build packages/dep/package.json: package_json dep/ditto.toml
   description = Generating package.json for dep
+  package-manager = pnpm
 
 


### PR DESCRIPTION
Prompted by https://github.com/ditto-lang/todomvc/pull/3

When using `pnpm` generated `package.json` files need to use the [`workspace` protocol](https://pnpm.io/workspaces#workspace-protocol-workspace).

In order to support `pnpm` (and other package managers in the future) this needs to be configurable.