### PR TITLE
Switch to `tracing` + flamegraphs 🔥

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,15 +47,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,7 +231,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -676,11 +667,9 @@ dependencies = [
  "ditto-fmt",
  "ditto-lsp",
  "ditto-make",
- "flexi_logger",
  "fs2",
  "futures-util",
  "indicatif",
- "log",
  "miette",
  "notify",
  "pathdiff",
@@ -696,6 +685,10 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-appender",
+ "tracing-flame",
+ "tracing-subscriber",
  "trycmd",
  "walkdir",
  "zip",
@@ -786,6 +779,7 @@ dependencies = [
  "ropey",
  "serde",
  "serde_json",
+ "tracing",
  "url",
 ]
 
@@ -800,7 +794,6 @@ dependencies = [
  "ditto-codegen-js",
  "ditto-config",
  "ditto-cst",
- "log",
  "miette",
  "path-slash",
  "pathdiff",
@@ -810,6 +803,7 @@ dependencies = [
  "serde_json",
  "similar-asserts",
  "thiserror",
+ "tracing",
  "trycmd",
  "walkdir",
 ]
@@ -950,23 +944,6 @@ checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "flexi_logger"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99659bcfd52cfece972bd00acb9dba7028094d47e699ea8b193b9aaebd5c362b"
-dependencies = [
- "ansi_term",
- "atty",
- "chrono",
- "glob",
- "lazy_static",
- "log",
- "regex",
- "rustversion",
- "thiserror",
 ]
 
 [[package]]
@@ -1741,6 +1718,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,6 +1843,12 @@ name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
@@ -2444,6 +2437,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2761,6 +2763,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+dependencies = [
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2874,7 +2903,30 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time 0.3.17",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2884,6 +2936,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-flame"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
+dependencies = [
+ "lazy_static",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3008,6 +3097,12 @@ checksum = "160f1ca3dc12c9e48f60b5b7a56092e372bda4ee2805f6c84ae337dd582fe12f"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/crates/ditto-cli/Cargo.toml
+++ b/crates/ditto-cli/Cargo.toml
@@ -18,9 +18,11 @@ ditto-fmt = { path = "../ditto-fmt" }
 clap = "4.0"
 chrono = "0.4"
 miette = { version = "5.5", features = ["fancy"] }
-log = "0.4"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+tracing-appender = "0.2"
+tracing-flame = "0.2"
 toml = "0.5"
-flexi_logger = "0.24"
 # https://github.com/notify-rs/notify/issues/249
 notify = "5.0.0"
 clearscreen = "1.0"

--- a/crates/ditto-cli/src/common.rs
+++ b/crates/ditto-cli/src/common.rs
@@ -1,6 +1,6 @@
-use log::debug;
 use miette::{miette, IntoDiagnostic, Result, WrapErr};
 use std::path::PathBuf;
+use tracing::debug;
 
 pub fn get_ditto_cache_dir() -> Result<PathBuf> {
     let cache_dir = if let Ok(cache_dir) = std::env::var("DITTO_CACHE_DIR") {

--- a/crates/ditto-cli/src/make.rs
+++ b/crates/ditto-cli/src/make.rs
@@ -4,7 +4,6 @@ use console::Style;
 use ditto_config::{read_config, Config, PackageName, CONFIG_FILE_NAME};
 use ditto_make::{self as make, BuildNinja, GetWarnings, PackageSources, Sources};
 use fs2::FileExt;
-use log::{debug, trace};
 use miette::{IntoDiagnostic, Result, WrapErr};
 use notify::Watcher;
 use std::{
@@ -16,6 +15,7 @@ use std::{
     process::{self, ExitStatus, Stdio},
     time::Instant,
 };
+use tracing::{debug, trace};
 
 pub static COMPILE_SUBCOMMAND: &str = "compile";
 
@@ -192,7 +192,7 @@ async fn run_watch(
                 true // return that a new run was started
             }
             other => {
-                log::trace!("Ignoring notify event: {:?}", other);
+                trace!("Ignoring notify event: {:?}", other);
 
                 false // return that no new run was started
             }
@@ -580,6 +580,7 @@ async fn make(
     }
 }
 
+#[tracing::instrument(skip_all)]
 fn generate_build_ninja(
     config_path: &Path,
     config: &Config,

--- a/crates/ditto-cli/src/ninja.rs
+++ b/crates/ditto-cli/src/ninja.rs
@@ -2,7 +2,6 @@ use crate::{common, spinner::Spinner};
 use clap::{arg, ArgMatches, Command};
 use console::Emoji;
 use futures_util::StreamExt;
-use log::debug;
 use miette::{miette, IntoDiagnostic, Result, WrapErr};
 use std::{
     env,
@@ -10,6 +9,7 @@ use std::{
     path::{Path, PathBuf},
     process,
 };
+use tracing::debug;
 
 pub fn command(name: impl Into<clap::builder::Str>) -> Command {
     Command::new(name)

--- a/crates/ditto-cli/src/pkg.rs
+++ b/crates/ditto-cli/src/pkg.rs
@@ -9,7 +9,6 @@ use ditto_config::{
     PackageSetPackages as Packages, PackageSpec, CONFIG_FILE_NAME,
 };
 use indicatif::MultiProgress;
-use log::{debug, warn};
 use miette::{miette, IntoDiagnostic, Result, WrapErr};
 use std::{
     collections::{hash_map::DefaultHasher, HashSet},
@@ -19,6 +18,7 @@ use std::{
     io::BufReader,
     path::{Path, PathBuf},
 };
+use tracing::{debug, warn};
 
 pub async fn check_packages_up_to_date(
     config: &Config,

--- a/crates/ditto-lsp/Cargo.toml
+++ b/crates/ditto-lsp/Cargo.toml
@@ -13,6 +13,7 @@ lsp-types = "0.93"
 serde = "1.0"
 serde_json = "1.0"
 log = "0.4"
+tracing = "0.1"
 miette = { version = "5.5" }
 url = "2.3"
 ditto-cst = { path = "../ditto-cst" }

--- a/crates/ditto-lsp/src/lib.rs
+++ b/crates/ditto-lsp/src/lib.rs
@@ -4,11 +4,11 @@
 mod semantic_tokens;
 
 use ditto_tree_sitter as tree_sitter;
-use log::debug;
 use miette::IntoDiagnostic;
 use ropey::Rope;
 use serde_json as json;
 use std::collections::HashMap;
+use tracing::debug;
 use url::Url;
 
 /// Run the language server.

--- a/crates/ditto-make/Cargo.toml
+++ b/crates/ditto-make/Cargo.toml
@@ -24,7 +24,7 @@ pathdiff = "0.2"
 path-slash = "0.2"
 semver = { version = "1.0", features = ["serde"] }
 thiserror = "1.0"
-log = "0.4"
+tracing = "0.1"
 # camino = "xx"  <-- start using this ASAP, it's made for exactly this purpose (see the "makefile problem")
 # rayon = "xx"   <-- more concurrency?
 

--- a/crates/ditto-make/src/build_ninja.rs
+++ b/crates/ditto-make/src/build_ninja.rs
@@ -27,6 +27,7 @@ pub type GetWarnings = impl FnOnce() -> Result<Vec<miette::Report>>;
 
 /// Generates a [build.ninja](https://ninja-build.org/manual.html#_writing_your_own_ninja_files)
 /// file and also returns a function for retrieving compiler warnings once `ninja` has run.
+#[tracing::instrument(skip_all)]
 pub fn generate_build_ninja(
     build_dir: PathBuf,
     ditto_bin: PathBuf,

--- a/crates/ditto-make/src/common.rs
+++ b/crates/ditto-make/src/common.rs
@@ -23,6 +23,7 @@ pub fn module_name_to_file_stem(module_name: ModuleName) -> PathBuf {
 }
 
 /// Serialize a value using a JSON if this is a debug build, and CBOR otherwise.
+#[tracing::instrument(skip_all)]
 pub fn serialize<W: Write, T: Serialize>(writer: W, value: &T) -> Result<()> {
     if cfg!(debug_assertions) {
         serde_json::to_writer_pretty(writer, value).into_diagnostic()
@@ -32,6 +33,7 @@ pub fn serialize<W: Write, T: Serialize>(writer: W, value: &T) -> Result<()> {
 }
 
 /// Deserialize a value using a JSON if this is a debug build, and CBOR otherwise.
+#[tracing::instrument]
 pub fn deserialize<T: DeserializeOwned>(path: &Path) -> Result<T> {
     let file = File::open(path).into_diagnostic()?;
     let reader = BufReader::new(file);

--- a/shell.nix
+++ b/shell.nix
@@ -86,6 +86,7 @@ pkgs.mkShell {
     pkgs.cargo-audit
     pkgs.cargo-outdated
     cargo-benchcmp
+    pkgs.inferno
 
     # Haskell stuff
     stack


### PR DESCRIPTION
I was using [`log`](https://crates.io/crates/log) but the cool kids seem to be using [`tracing`](https://crates.io/crates/tracing) 😎 

The big selling point for me is [`tracing-flame`](https://crates.io/crates/tracing-flame) which means I can generate flamegraphs and start identifying bottlenecks 🧐 

```console
$ rm -rf .ditto   # with a clean build
$ DITTO_TRACE_DIR=.ditto/traces ditto make
$ cat .ditto/traces/* | inferno-flamegraph --flamechart > flamegraph.svg
PROFIT
```

