### PR TITLE
Swap ciborium for bincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bincode"
+version = "2.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb50c5a2ef4b9b1e7ae73e3a73b52ea24b20312d629f9c4df28260b7ad2c3c4"
+dependencies = [
+ "bincode_derive",
+ "serde",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a45a23389446d2dd25dc8e73a7a3b3c43522b630cac068927f0649d43d719d2"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +648,7 @@ dependencies = [
 name = "ditto-ast"
 version = "0.0.1"
 dependencies = [
+ "bincode",
  "ditto-cst",
  "indexmap",
  "non-empty-vec",
@@ -640,6 +660,7 @@ dependencies = [
 name = "ditto-checker"
 version = "0.0.1"
 dependencies = [
+ "bincode",
  "datatest-stable",
  "ditto-ast",
  "ditto-cst",
@@ -739,6 +760,7 @@ dependencies = [
 name = "ditto-cst"
 version = "0.0.1"
 dependencies = [
+ "bincode",
  "datatest-stable",
  "itertools",
  "lalrpop",
@@ -793,6 +815,7 @@ dependencies = [
 name = "ditto-make"
 version = "0.0.1"
 dependencies = [
+ "bincode",
  "ciborium",
  "clap 4.0.26",
  "ditto-ast",
@@ -3020,6 +3043,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "virtue"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b60dcd6a64dd45abf9bd426970c9843726da7fc08f44cd6fcebf68c21220a63"
 
 [[package]]
 name = "wait-timeout"

--- a/crates/ditto-ast/Cargo.toml
+++ b/crates/ditto-ast/Cargo.toml
@@ -13,4 +13,5 @@ serde = { version = "1.0", features = ["derive"] }
 petgraph = "0.6"
 non-empty-vec = { version = "0.2", features = ["serde"] }
 indexmap = { version = "1.9", features = ["serde"] }
+bincode = { version = "2.0.0-rc.2", features = ["serde"] }
 #unindent = "xx"  <-- might come in useful for smart multi-line strings (like Nix)

--- a/crates/ditto-ast/src/expression.rs
+++ b/crates/ditto-ast/src/expression.rs
@@ -1,12 +1,13 @@
 use crate::{
     FullyQualifiedName, FullyQualifiedProperName, Name, ProperName, Span, Type, UnusedName,
 };
+use bincode::{Decode, Encode};
 use indexmap::IndexMap;
 use non_empty_vec::NonEmpty;
 use serde::{Deserialize, Serialize};
 
 /// The real business value.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
 #[serde(tag = "expression", content = "data")]
 pub enum Expression {
     /// Everyone's favourite: the humble function
@@ -81,6 +82,7 @@ pub enum Expression {
         expression: Box<Self>,
 
         /// Patterns to be matched against and their corresponding expressions.
+        #[bincode(with_serde)]
         arms: NonEmpty<(Pattern, Self)>,
     },
     /// A value constructor local to the current module, e.g. `Just` and `Ok`.
@@ -226,6 +228,7 @@ pub enum Expression {
         /// The expression being updated.
         target: Box<Self>,
         /// The record updates.
+        #[bincode(with_serde)]
         fields: IndexMap<Name, Self>,
     },
     /// An array literal.
@@ -251,6 +254,7 @@ pub enum Expression {
         record_type: Type,
 
         /// Record fields.
+        #[bincode(with_serde)]
         fields: IndexMap<Name, Self>,
     },
     /// `true`
@@ -551,7 +555,7 @@ impl Expression {
 /// ```ditto
 /// some_function(argument)
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
 pub enum Argument {
     /// A standard expression argument.
     /// Could be a variable, could be another function call.
@@ -574,7 +578,7 @@ impl Argument {
 }
 
 /// A pattern to be matched.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
 pub enum Pattern {
     /// A local constructor pattern.
     LocalConstructor {
@@ -611,7 +615,7 @@ pub enum Pattern {
 }
 
 /// A chain of Effect statements.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
 pub enum Effect {
     /// `do { name <- expression; rest }`
     Bind {
@@ -646,7 +650,7 @@ pub enum Effect {
 }
 
 /// A value declaration that appears within a `let` expression.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
 pub struct LetValueDeclaration {
     /// The pattern containing names to be bound.
     pub pattern: Pattern,

--- a/crates/ditto-ast/src/graph.rs
+++ b/crates/ditto-ast/src/graph.rs
@@ -1,5 +1,6 @@
 //! A convenient graph API, based largely on Haskell's [`Data.Graph`](https://hackage.haskell.org/package/containers-0.6.5.1/docs/Data-Graph.html) module, and built on [`petgraph`](https://crates.io/crates/petgraph).
 
+use bincode::{Decode, Encode};
 use petgraph::{algo::kosaraju_scc, graph::NodeIndex, Graph}; // REVIEW or tarjan?
 use serde::{Deserialize, Serialize};
 use std::{
@@ -10,7 +11,7 @@ use std::{
 /// Strongly connected component.
 ///
 /// <https://en.wikipedia.org/wiki/Strongly_connected_component>
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode)]
 #[serde(untagged)]
 pub enum Scc<Node> {
     /// A single vertex that is not in any cycle.

--- a/crates/ditto-ast/src/kind.rs
+++ b/crates/ditto-ast/src/kind.rs
@@ -1,10 +1,11 @@
+use bincode::{Decode, Encode};
 use non_empty_vec::NonEmpty;
 use serde::{Deserialize, Serialize};
 
 /// The kind of types.
 ///
 /// Note that there is currently no source representation for kinds.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode)]
 pub enum Kind {
     /// Also known as `*` to functional programming folk.
     Type,
@@ -20,6 +21,7 @@ pub enum Kind {
     /// Also note that the "return kind" can only be `Kind::Type` at the moment.
     Function {
         /// The kinds of the arguments this type expects.
+        #[bincode(with_serde)]
         parameters: NonEmpty<Self>,
     },
     /// A series of labelled types. Used for records.

--- a/crates/ditto-ast/src/module.rs
+++ b/crates/ditto-ast/src/module.rs
@@ -1,11 +1,12 @@
 use crate::{graph::Scc, Expression, Kind, ModuleName, Name, ProperName, Span, Type};
+use bincode::{Decode, Encode};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 /// A ditto module.
 ///
 /// A module captures three namespaces: types, constructors and values.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Encode, Decode)]
 pub struct Module {
     /// The name of the module, e.g. `Some.Module`.
     ///
@@ -19,14 +20,17 @@ pub struct Module {
     pub exports: ModuleExports,
 
     /// Types defined in this module.
+    #[bincode(with_serde)]
     pub types: ModuleTypes,
 
     /// Types defined in this module.
+    #[bincode(with_serde)]
     pub constructors: ModuleConstructors,
 
     /// Top-level values defined within the module.
     ///
     /// The flattened names should form a unique list.
+    #[bincode(with_serde)]
     pub values: ModuleValues,
 
     /// The topological sort order of `values`.
@@ -39,7 +43,7 @@ pub struct Module {
 pub type ModuleTypes = IndexMap<ProperName, ModuleType>;
 
 /// A type defined by a module.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Encode, Decode)]
 pub enum ModuleType {
     /// A type introduced by an ordinary type declaration.
     Type {
@@ -123,7 +127,7 @@ pub type ModuleConstructors = IndexMap<ProperName, ModuleConstructor>;
 pub type ModuleValues = IndexMap<Name, ModuleValue>;
 
 /// A value defined by a module.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
 pub struct ModuleValue {
     /// Documentation comments (if any).
     pub doc_comments: Vec<String>,
@@ -149,7 +153,7 @@ impl Module {
 }
 
 /// A single constructor, e.g. the `Ok` constructor for `Result`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
 pub struct ModuleConstructor {
     /// Documentation comments (if any).
     pub doc_comments: Vec<String>,
@@ -184,13 +188,16 @@ impl ModuleConstructor {
 }
 
 /// Everything that a module can expose.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Encode, Decode)]
 pub struct ModuleExports {
     /// Exposed type constructors.
+    #[bincode(with_serde)]
     pub types: ModuleExportsTypes,
     /// Exposed type constructors.
+    #[bincode(with_serde)]
     pub constructors: ModuleExportsConstructors,
     /// Exposed values.
+    #[bincode(with_serde)]
     pub values: ModuleExportsValues,
 }
 
@@ -198,7 +205,7 @@ pub struct ModuleExports {
 pub type ModuleExportsTypes = IndexMap<ProperName, ModuleExportsType>;
 
 /// A single exposed type.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
 pub enum ModuleExportsType {
     /// An exported type introduced by an ordinary type declaration.
     Type {
@@ -252,7 +259,7 @@ impl ModuleExportsType {
 pub type ModuleExportsConstructors = IndexMap<ProperName, ModuleExportsConstructor>;
 
 /// A single exposed constructor.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
 pub struct ModuleExportsConstructor {
     /// Documentation comments (if any).
     pub doc_comments: Vec<String>,
@@ -270,7 +277,7 @@ pub struct ModuleExportsConstructor {
 pub type ModuleExportsValues = IndexMap<Name, ModuleExportsValue>;
 
 /// A single exposed value.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode)]
 pub struct ModuleExportsValue {
     /// Documentation comments (if any).
     pub doc_comments: Vec<String>,

--- a/crates/ditto-ast/src/name.rs
+++ b/crates/ditto-ast/src/name.rs
@@ -1,10 +1,13 @@
+use bincode::{Decode, Encode};
 use ditto_cst as cst;
 use non_empty_vec::NonEmpty;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// A "name" begins with a lower case letter.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Encode, Decode,
+)]
 pub struct Name(pub String);
 
 impl fmt::Display for Name {
@@ -20,7 +23,9 @@ impl From<cst::Name> for Name {
 }
 
 /// An "unused name" begins with a single underscore.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Encode, Decode,
+)]
 pub struct UnusedName(pub String);
 
 impl fmt::Display for UnusedName {
@@ -36,7 +41,9 @@ impl From<cst::UnusedName> for UnusedName {
 }
 
 /// A "proper name" begins with an upper case letter.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Encode, Decode,
+)]
 pub struct ProperName(pub String);
 
 impl fmt::Display for ProperName {
@@ -52,7 +59,7 @@ impl From<cst::ProperName> for ProperName {
 }
 
 /// A package name consists of lower case letters, numbers and hyphens. It must start with a letter.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode)]
 pub struct PackageName(pub String);
 
 impl fmt::Display for PackageName {
@@ -70,8 +77,8 @@ impl From<cst::PackageName> for PackageName {
 /// A [ModuleName] is a non-empty collection of [ProperName]s.
 ///
 /// In the source these are joined with a dot.
-#[derive(Debug, Clone, Eq, Serialize, Deserialize)]
-pub struct ModuleName(pub NonEmpty<ProperName>);
+#[derive(Debug, Clone, Eq, Serialize, Deserialize, Encode, Decode)]
+pub struct ModuleName(#[bincode(with_serde)] pub NonEmpty<ProperName>);
 
 impl ModuleName {
     /// Convert a module name to a string, joining the component [ProperName]s with the given `separator`.
@@ -134,7 +141,7 @@ impl From<cst::QualifiedProperName> for ModuleName {
 }
 
 /// Something is "qualified" if it can have an initial module name.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode)]
 pub struct Qualified<Value> {
     /// The optional qualifier.
     pub module_name: Option<ProperName>,
@@ -187,7 +194,7 @@ where
 pub type FullyQualifiedModuleName = (Option<PackageName>, ModuleName);
 
 /// The canonical name for an identifier.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode)]
 pub struct FullyQualified<Value> {
     /// The package and module to which it belongs.
     pub module_name: FullyQualifiedModuleName,

--- a/crates/ditto-ast/src/type.rs
+++ b/crates/ditto-ast/src/type.rs
@@ -1,11 +1,12 @@
 use crate::{FullyQualifiedProperName, Kind, Name, ProperName, QualifiedProperName};
+use bincode::{Decode, Encode};
 use indexmap::IndexMap;
 use non_empty_vec::NonEmpty;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// The type of expressions.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, PartialEq, Eq)]
 #[serde(tag = "type", content = "data")]
 pub enum Type {
     /// A `Call` type invokes a parameterized type.
@@ -21,6 +22,7 @@ pub enum Type {
         /// Type being called.
         function: Box<Self>,
         /// The non-empty arguments list.
+        #[bincode(with_serde)]
         arguments: NonEmpty<Self>,
     },
     /// The type of functions.
@@ -79,6 +81,7 @@ pub enum Type {
         /// Should be either `Kind::Type` or `Kind::Row`.
         kind: Kind,
         /// The labelled types.
+        #[bincode(with_serde)]
         row: Row,
     },
     /// An _open_ record type.
@@ -94,6 +97,7 @@ pub enum Type {
         /// Optional name for the type `var`.
         source_name: Option<Name>,
         /// The labelled types.
+        #[bincode(with_serde)]
         row: Row,
     },
 }
@@ -102,7 +106,7 @@ pub enum Type {
 pub type Row = IndexMap<Name, Type>;
 
 /// Ditto's primitive types.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, PartialEq, Eq)]
 pub enum PrimType {
     /// `do { return 5 } : Effect(Int)`
     Effect,

--- a/crates/ditto-checker/Cargo.toml
+++ b/crates/ditto-checker/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = "1.0"
 simsearch = "0.2"
 indexmap = "1.9"
 serde_json = "1.0"
+bincode = "2.0.0-rc.2"
 
 [dev-dependencies]
 similar-asserts = "1.4"

--- a/crates/ditto-cst/Cargo.toml
+++ b/crates/ditto-cst/Cargo.toml
@@ -15,6 +15,7 @@ thiserror = "1.0"
 lalrpop-util = "0.19.8"
 regex = "1"
 logos = "0.12"
+bincode = "2.0.0-rc.2"
 #simsearch = "xx"   <-- for suggestions
 #unindent = "xx"  <-- might come in useful for smart multi-line strings (like Nix)
 #codespan = "xx" <-- might be a good replacement for our `Span` type

--- a/crates/ditto-cst/src/token.rs
+++ b/crates/ditto-cst/src/token.rs
@@ -1,7 +1,8 @@
+use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
 /// A source span.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Encode, Decode, PartialEq, Eq, Hash)]
 pub struct Span {
     /// The start byte offset.
     pub start_offset: usize,

--- a/crates/ditto-make/Cargo.toml
+++ b/crates/ditto-make/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 petgraph = "0.6"
 ciborium = "0.2"
+bincode = "2.0.0-rc.2"
 pathdiff = "0.2"
 path-slash = "0.2"
 semver = { version = "1.0", features = ["serde"] }

--- a/crates/ditto-make/src/compile.rs
+++ b/crates/ditto-make/src/compile.rs
@@ -89,7 +89,7 @@ pub fn run(matches: &ArgMatches) -> Result<()> {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, bincode::Encode, bincode::Decode)]
 pub struct WarningsBundle {
     pub name: String,
     pub source: String,
@@ -218,15 +218,15 @@ fn run_ast(build_dir: &str, inputs: Vec<String>, outputs: Vec<String>) -> Result
         let path = Path::new(&output);
         match full_extension(path) {
             Some(common::EXTENSION_AST) => {
-                let file = File::create(path).into_diagnostic()?;
-                common::serialize(file, &(&ditto_input_name, &ast))?;
+                let mut file = File::create(path).into_diagnostic()?;
+                common::serialize(&mut file, &(&ditto_input_name, &ast))?;
             }
             Some(common::EXTENSION_AST_EXPORTS) => {
-                let file = File::create(path).into_diagnostic()?;
-                common::serialize(file, &(&ast.module_name, &ast.exports))?;
+                let mut file = File::create(path).into_diagnostic()?;
+                common::serialize(&mut file, &(&ast.module_name, &ast.exports))?;
             }
             Some(common::EXTENSION_CHECKER_WARNINGS) => {
-                let file = File::create(path).into_diagnostic()?;
+                let mut file = File::create(path).into_diagnostic()?;
                 let warnings_bundle = if warnings.is_empty() {
                     None
                 } else {
@@ -236,7 +236,7 @@ fn run_ast(build_dir: &str, inputs: Vec<String>, outputs: Vec<String>) -> Result
                         warnings: warnings.clone(),
                     })
                 };
-                common::serialize(file, &warnings_bundle)?;
+                common::serialize(&mut file, &warnings_bundle)?;
                 print_warnings = false;
             }
             other => panic!("unexpected output extension: {:#?}", other),


### PR DESCRIPTION
The flamegraphs from #183 showed that `ditto make` was spending a _significant_ amount of time serializing and deserializing.

This _could_ be because [`ciborium`](https://crates.io/crates/ciborium) is slow...

https://github.com/djkoloski/rust_serialization_benchmark shows there are definitely faster options. 