### PR TITLE
Fix bug in generated JS condition order 🐞 

### DIFF
--- a/crates/ditto-codegen-js/src/convert.rs
+++ b/crates/ditto-codegen-js/src/convert.rs
@@ -756,10 +756,10 @@ fn convert_pattern(
         let condition =
             conditions
                 .iter()
-                .fold(condition.clone(), |rhs, lhs| Expression::Operator {
+                .fold(condition.clone(), |lhs, rhs| Expression::Operator {
                     op: Operator::And,
-                    lhs: Box::new(lhs.clone()),
-                    rhs: Box::new(rhs),
+                    lhs: Box::new(lhs),
+                    rhs: Box::new(rhs.clone()),
                 });
         (Some(condition), assignments)
     } else {

--- a/crates/ditto-codegen-js/tests/golden/match_expressions.ditto
+++ b/crates/ditto-codegen-js/tests/golden/match_expressions.ditto
@@ -65,3 +65,10 @@ complex_matched_expresion = fn (x) ->
     | Just(y) -> [y]
     | Nothing -> [2]
     end
+
+nested_pattern = fn (m) ->
+    match m with
+    | Just(Just(Just(Just(_)))) -> true
+    | Nothing -> false
+    | _ -> false
+    end

--- a/crates/ditto-codegen-js/tests/golden/match_expressions.js
+++ b/crates/ditto-codegen-js/tests/golden/match_expressions.js
@@ -8,6 +8,20 @@ function ManyFields($0, $1, $2, $3) {
   return ["ManyFields", $0, $1, $2, $3];
 }
 const Nothing = ["Nothing"];
+function nested_pattern(m) {
+  if (
+    m[0] === "Just" &&
+    m[1][0] === "Just" &&
+    m[1][1][0] === "Just" &&
+    m[1][1][1][0] === "Just"
+  ) {
+    return true;
+  }
+  if (m[0] === "Nothing") {
+    return false;
+  }
+  return false;
+}
 function id(a) {
   return a;
 }
@@ -113,6 +127,7 @@ export {
   is_just,
   many_fields_to_array,
   mk_five,
+  nested_pattern,
   to_string,
   very_function_arms,
   with_default,


### PR DESCRIPTION
The order of conditions generated by a `match` expression is significant (we depend on the short-circuiting of `&&`) and the generated order was wrong. This PR fixes it.