### PR TITLE
Fix record formatting bug 🐛 

### DIFF
--- a/crates/ditto-fmt/src/expression.rs
+++ b/crates/ditto-fmt/src/expression.rs
@@ -345,7 +345,7 @@ pub fn gen_expression(expr: Expression, _needs_parens: bool) -> PrintItems {
             items.extend(gen_open_brace(open_brace));
 
             let gen_separated_values_result =
-                gen_comma_sep1(updates, gen_record_field, force_use_new_lines);
+                gen_comma_sep1(updates, gen_record_field, true, force_use_new_lines);
 
             let is_multiple_lines = gen_separated_values_result.is_multi_line_condition_ref;
 
@@ -371,9 +371,7 @@ pub fn gen_expression(expr: Expression, _needs_parens: bool) -> PrintItems {
                     items.extend(gen_expression(target, true));
                     items.extend(space());
                     items.extend(gen_pipe(pipe));
-                    items.extend(space());
                     items.extend(element_items.into());
-                    items.extend(space());
                     items.extend(gen_close_brace(close_brace));
                     items
                 },

--- a/crates/ditto-fmt/src/type.rs
+++ b/crates/ditto-fmt/src/type.rs
@@ -64,7 +64,7 @@ pub fn gen_type(t: Type) -> PrintItems {
             let force_use_new_lines =
                 open_brace.0.has_comments() || var.has_comments() || pipe.0.has_comments();
             let gen_separated_values_result =
-                gen_comma_sep1(fields, gen_record_type_field, force_use_new_lines);
+                gen_comma_sep1(fields, gen_record_type_field, true, force_use_new_lines);
 
             let fields = gen_separated_values_result.items.into_rc_path();
             items.push_condition(conditions::if_true_or(
@@ -73,6 +73,7 @@ pub fn gen_type(t: Type) -> PrintItems {
                     .is_multi_line_condition_ref
                     .create_resolver(),
                 {
+                    // multi-line
                     let mut items = gen_open_brace(open_brace.clone());
                     items.push_signal(Signal::NewLine);
                     items.extend(ir_helpers::with_indent({
@@ -86,14 +87,13 @@ pub fn gen_type(t: Type) -> PrintItems {
                     items
                 },
                 {
+                    // single-line
                     let mut items = gen_open_brace(open_brace);
                     items.push_signal(Signal::SpaceOrNewLine);
                     items.extend(gen_name(var));
                     items.extend(space());
                     items.extend(gen_pipe(pipe));
-                    items.extend(space());
                     items.extend(fields.into());
-                    items.extend(space());
                     items.extend(gen_close_brace(close_brace));
                     items
                 },

--- a/crates/ditto-fmt/tests/golden/records.ditto
+++ b/crates/ditto-fmt/tests/golden/records.ditto
@@ -4,6 +4,6 @@ module Records exports (..)
 items = [
     { key = "a", value = unit },
     { key = "b", value = unit },
-    {key = "c", value = unit },
+    { key = "c", value = unit },
     { key = "d", value = unit },
 ]


### PR DESCRIPTION
Under some circumstances record formatting was misbehaving.

A good example is some code from the (upcoming 👀) playground (diff is before and after this change):

```diff
diff --git a/ditto-src/Main.ditto b/ditto-src/Main.ditto
index 25a7bc4..90c02f8 100644
--- a/ditto-src/Main.ditto
+++ b/ditto-src/Main.ditto
@@ -242,8 +242,7 @@ update = fn (state: State, event: Event): Next ->
         task = Just(Task.succeed(CompileClicked)),
     }
     | EditorInitError(error) -> {
-        state = {
-            state |editor = EditorInitFailed(error)},
+        state = { state | editor = EditorInitFailed(error) },
         task = Nothing,
     }
     | EditorUnmounted -> {
@@ -285,8 +284,7 @@ update = fn (state: State, event: Event): Next ->
         task = Nothing,
     }
     | CompilerInitError(error) -> {
-        state = {
-            state |compiler = CompilerInitFailed(error)},
+        state = { state | compiler = CompilerInitFailed(error) },
         task = Nothing,
     }
     | CompileClicked ->
@@ -302,13 +300,13 @@ update = fn (state: State, event: Event): Next ->
         | _ -> { state = state, task = Nothing }
         end
     | CompiledJs(compiled) -> {
-        state = {
-            state |output = Just(Output(compiled.js, compiled.warnings))},
+        state = { state |
+            output = Just(Output(compiled.js, compiled.warnings)),
+        },
         task = Nothing,
     }
     | CompileJsError(error) -> {
-        state = {
-            state |output = Just(CompileError(error))},
+        state = { state | output = Just(CompileError(error)) },
         task = Nothing,
     }
```