### PR TITLE
Logging improvements 📡 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3059,17 +3059,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
  "nu-ansi-term",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/crates/ditto-cli/Cargo.toml
+++ b/crates/ditto-cli/Cargo.toml
@@ -19,7 +19,7 @@ clap = "4.0"
 time = { version = "0.3", features = ["serde-human-readable"] }
 miette = { version = "5.5", features = ["fancy"] }
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["json"] }
 tracing-appender = "0.2"
 tracing-flame = "0.2"
 toml = "0.5"

--- a/crates/ditto-cli/src/main.rs
+++ b/crates/ditto-cli/src/main.rs
@@ -163,7 +163,7 @@ async fn try_main() -> Result<()> {
 
         let mut fmt_layer = tracing_subscriber::fmt::Layer::new().with_writer(non_blocking);
         fmt_layer.set_ansi(false);
-        Some(fmt_layer)
+        Some(fmt_layer.with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE))
     } else {
         None
     };

--- a/crates/ditto-cli/src/make.rs
+++ b/crates/ditto-cli/src/make.rs
@@ -353,7 +353,6 @@ async fn run_once(
         // Crash if we fail to release the lock otherwise things are likely to misbehave...
         .expect("Error releasing lock on build directory");
 
-    // FIXME: this isn't always logged - do we need to await something from tracing_subscriber?
     debug!("make ran in {}ms", now.elapsed().as_millis());
 
     result

--- a/crates/ditto-cli/src/make.rs
+++ b/crates/ditto-cli/src/make.rs
@@ -353,6 +353,7 @@ async fn run_once(
         // Crash if we fail to release the lock otherwise things are likely to misbehave...
         .expect("Error releasing lock on build directory");
 
+    // FIXME: this isn't always logged - do we need to await something from tracing_subscriber?
     debug!("make ran in {}ms", now.elapsed().as_millis());
 
     result
@@ -581,7 +582,7 @@ async fn make(
     }
 }
 
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(level = "trace", skip_all)]
 fn generate_build_ninja(
     config_path: &Path,
     config: &Config,

--- a/crates/ditto-cli/src/make.rs
+++ b/crates/ditto-cli/src/make.rs
@@ -485,8 +485,9 @@ async fn make(
         .env("CLICOLOR_FORCE", "1")
         // Pass `is_plain` logic down to CLI calls made by ninja
         .env("DITTO_PLAIN", common::is_plain().to_string())
-        .envs(if let Ok(log_dir) = std::env::var("DITTO_LOG_DIR") {
-            vec![("DITTO_LOG_DIR", log_dir)]
+        // Pass the log file location down too
+        .envs(if let Ok(log_file) = std::env::var("DITTO_LOG_FILE") {
+            vec![("DITTO_LOG_FILE", log_file)]
         } else {
             vec![]
         })

--- a/crates/ditto-make/src/build_ninja.rs
+++ b/crates/ditto-make/src/build_ninja.rs
@@ -27,7 +27,7 @@ pub type GetWarnings = impl FnOnce() -> Result<Vec<miette::Report>>;
 
 /// Generates a [build.ninja](https://ninja-build.org/manual.html#_writing_your_own_ninja_files)
 /// file and also returns a function for retrieving compiler warnings once `ninja` has run.
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn generate_build_ninja(
     build_dir: PathBuf,
     ditto_bin: PathBuf,

--- a/crates/ditto-make/src/common.rs
+++ b/crates/ditto-make/src/common.rs
@@ -23,7 +23,7 @@ pub fn module_name_to_file_stem(module_name: ModuleName) -> PathBuf {
 }
 
 /// Serialize a value using a JSON if this is a debug build, and CBOR otherwise.
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn serialize<W: Write, T: Serialize>(writer: W, value: &T) -> Result<()> {
     if cfg!(debug_assertions) {
         serde_json::to_writer_pretty(writer, value).into_diagnostic()
@@ -33,7 +33,7 @@ pub fn serialize<W: Write, T: Serialize>(writer: W, value: &T) -> Result<()> {
 }
 
 /// Deserialize a value using a JSON if this is a debug build, and CBOR otherwise.
-#[tracing::instrument]
+#[tracing::instrument(level = "trace")]
 pub fn deserialize<T: DeserializeOwned>(path: &Path) -> Result<T> {
     let file = File::open(path).into_diagnostic()?;
     let reader = BufReader::new(file);

--- a/crates/ditto-make/src/compile.rs
+++ b/crates/ditto-make/src/compile.rs
@@ -96,7 +96,7 @@ pub struct WarningsBundle {
     pub warnings: Vec<checker::WarningReport>,
 }
 
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(level = "trace", skip_all)]
 fn run_ast(build_dir: &str, inputs: Vec<String>, outputs: Vec<String>) -> Result<()> {
     let mut ditto_input = None;
     let mut everything = checker::Everything::default();
@@ -251,7 +251,7 @@ fn check_module(
     Ok((module, warnings))
 }
 
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(level = "trace", skip_all)]
 fn run_js(inputs: Vec<String>, outputs: Vec<String>) -> Result<()> {
     let mut ditto_input_path = None;
     let mut ast = None;
@@ -330,13 +330,13 @@ fn run_js(inputs: Vec<String>, outputs: Vec<String>) -> Result<()> {
     Ok(())
 }
 
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(level = "trace", skip_all)]
 fn generate_javascript(config: &js::Config, ast: ast::Module) -> String {
     js::codegen(config, ast)
 }
 
 /// Generates a `package.json` from a `ditto.toml` input.
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(level = "trace", skip_all)]
 fn run_package_json(input: &str, output: &str) -> Result<()> {
     use serde_json::{json, Map, Value};
 


### PR DESCRIPTION
`DITTO_LOG_DIR` is no more, now all logs are written to a single file: `DITTO_LOG_FILE` 🙌 .

Those logs are also now structured (JSON) and include span timings, which will be useful for performance analysis. 

It _might_ make sense to support opt-in human-readable logs, but I'll add that as/when necessary.