### PR TITLE
Add R script for analysing log span timings

### DIFF
--- a/scripts/log-analysis/.gitignore
+++ b/scripts/log-analysis/.gitignore
@@ -1,0 +1,2 @@
+logs.ndjson
+plot.png

--- a/scripts/log-analysis/main.R
+++ b/scripts/log-analysis/main.R
@@ -1,0 +1,45 @@
+library(magrittr)
+library(ggplot2)
+
+logs <- jsonlite::stream_in(file("logs.ndjson"), verbose = FALSE)
+
+parse_duration <- function(s) {
+  n <- as.numeric(substr(s, 1, nchar(s) - 2))
+  ifelse(endsWith(s, "ms"), n, n / 1000)
+}
+
+is_outlier <- function(ms) {
+  # outliers are greater than 10ms
+  return(ms > 10)
+}
+
+data <- dplyr::bind_rows(
+  phase = logs$span$name,
+  file = logs$span$source_name,
+  duration_ms = parse_duration(logs$fields$time.busy)
+) %>%
+  dplyr::filter(
+    phase %in% c("parse_cst", "check_module", "generate_javascript")
+  ) %>%
+  dplyr::mutate(
+    phase = dplyr::recode(phase,
+      parse_cst = "Parse",
+      check_module = "Typecheck",
+      generate_javascript = "Codegen"
+    ),
+    outlier = ifelse(is_outlier(duration_ms), file, as.numeric(NA))
+  )
+
+plot <- ggplot(
+  data,
+  aes(
+    x = factor(phase, levels = c("Parse", "Typecheck", "Codegen")),
+    y = duration_ms
+  )
+) +
+  geom_boxplot() +
+  geom_text(aes(label = outlier), na.rm = TRUE, hjust = -0.1, size = 3) +
+  xlab("Phase") +
+  ylab("Time (milliseconds)")
+
+ggsave("plot.png", plot = plot)

--- a/scripts/log-analysis/shell.nix
+++ b/scripts/log-analysis/shell.nix
@@ -1,0 +1,13 @@
+let pkgs = import ../../nixpkgs.nix { };
+in pkgs.mkShell {
+  buildInputs = [
+    (pkgs.rWrapper.override {
+      packages = with pkgs.rPackages; [
+        languageserver
+        jsonlite
+        dplyr
+        ggplot2
+      ];
+    })
+  ];
+}


### PR DESCRIPTION
Following #211 this is a little script to help with identifying performance bottlenecks.

For example, I generated build logs for https://github.com/ditto-lang/playground/tree/cd5185b2ccc2fdc1c0b454dbed05dfcb61157a0f using:

```console
$ ditto make
$ rm -rf .ditto/build
$ DITTO_LOG_FILE=logs.ndjson ditto make
```

Then ran this script with:

```console
$ nix-shell --command 'R -s -f main.R'
```

Which gave me: 

![plot](https://user-images.githubusercontent.com/12185627/224494871-74310e9a-0d79-49cc-850e-f2a157efe955.png)

Which is quite interesting 🤔
