### PR TITLE
Add some benchmarks ⏱️ 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +276,17 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "bitflags",
+ "textwrap 0.11.0",
+ "unicode-width",
+]
+
+[[package]]
+name = "clap"
 version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
@@ -282,7 +299,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
+ "textwrap 0.15.1",
 ]
 
 [[package]]
@@ -436,6 +453,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+dependencies = [
+ "atty",
+ "cast",
+ "clap 2.34.0",
+ "criterion-plot",
+ "csv",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +560,27 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "csv"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b015497079b9a9d69c02ad25de6c0a6edef051ea6360a327d0bd05802ef64ad"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "dashmap"
@@ -613,6 +687,18 @@ dependencies = [
  "non-empty-vec",
  "petgraph",
  "serde",
+]
+
+[[package]]
+name = "ditto-benchmarks"
+version = "0.0.1"
+dependencies = [
+ "criterion",
+ "ditto-ast",
+ "ditto-checker",
+ "ditto-codegen-js",
+ "ditto-cst",
+ "serde_json",
 ]
 
 [[package]]
@@ -1609,7 +1695,7 @@ dependencies = [
  "supports-hyperlinks",
  "supports-unicode",
  "terminal_size",
- "textwrap",
+ "textwrap 0.15.1",
  "thiserror",
  "unicode-width",
 ]
@@ -1780,6 +1866,12 @@ name = "once_cell"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
@@ -2001,6 +2093,34 @@ name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
+name = "plotters"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2417,6 +2537,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2758,6 +2888,15 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
@@ -2839,6 +2978,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "crates/ditto-cst",
   "crates/ditto-ast",
   "crates/ditto-checker",
+  "crates/ditto-benchmarks",
   "crates/ditto-config",
   "crates/ditto-codegen-js",
   "crates/ditto-fmt",

--- a/crates/ditto-benchmarks/Cargo.toml
+++ b/crates/ditto-benchmarks/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "ditto-benchmarks"
+version = "0.0.1"
+edition = "2021"
+license = "BSD-3-Clause"
+
+[lib]
+doctest = false
+
+[dependencies]
+ditto-cst = { path = "../ditto-cst" }
+ditto-ast = { path = "../ditto-ast" }
+ditto-checker = { path = "../ditto-checker" }
+ditto-codegen-js = { path = "../ditto-codegen-js" }
+serde_json = "1.0"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "vdom-html"
+# path = "benches/vdom-Html/criterion.rs"
+harness = false

--- a/crates/ditto-benchmarks/benches/common/mod.rs
+++ b/crates/ditto-benchmarks/benches/common/mod.rs
@@ -1,0 +1,41 @@
+pub fn preamble(
+    source: &'static str,
+    module_exports: Vec<&'static str>,
+) -> (
+    ditto_cst::Module,
+    ditto_ast::Module,
+    ditto_checker::Everything,
+    ditto_codegen_js::Config,
+) {
+    let cst_module = ditto_cst::Module::parse(source).unwrap();
+    let mut everything = ditto_checker::Everything::default();
+    for module_exports_json in module_exports {
+        let (mn, exports): (ditto_ast::ModuleName, ditto_ast::ModuleExports) =
+            serde_json::from_str(module_exports_json).unwrap();
+        everything.modules.insert(mn, exports);
+    }
+    let (ast_module, warnings) =
+        ditto_checker::check_module(&everything, cst_module.clone()).unwrap();
+
+    assert!(warnings.is_empty());
+    return (cst_module, ast_module, everything, codegen_js_config());
+}
+
+pub fn codegen_js_config() -> ditto_codegen_js::Config {
+    ditto_codegen_js::Config {
+        module_name_to_path: Box::new(|(package_name, module_name)| {
+            let module_path = module_name
+                .0
+                .into_iter()
+                .map(|proper_name| proper_name.0)
+                .collect::<Vec<_>>()
+                .join(".");
+
+            match package_name {
+                None => module_path,
+                Some(ditto_ast::PackageName(pkg)) => format!("{}/{}", pkg, module_path),
+            }
+        }),
+        foreign_module_path: "./foreign.js".into(),
+    }
+}

--- a/crates/ditto-benchmarks/benches/vdom-html.rs
+++ b/crates/ditto-benchmarks/benches/vdom-html.rs
@@ -1,0 +1,37 @@
+mod common;
+
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let source = include_str!("vdom-html/source.ditto");
+    let (cst_module, ast_module, everything, codegen_js_config) = common::preamble(
+        source,
+        vec![include_str!("vdom-html/Attributes.ast-exports")],
+    );
+    let mut group = c.benchmark_group("vdom:Html");
+    group.bench_function("parse", |b| {
+        b.iter(|| ditto_cst::Module::parse(black_box(source)).unwrap())
+    });
+    group.bench_function("check", |b| {
+        b.iter_batched(
+            || cst_module.clone(),
+            |cst_module| ditto_checker::check_module(black_box(&everything), black_box(cst_module)),
+            BatchSize::LargeInput,
+        )
+    });
+    group.bench_function("codegen-js", |b| {
+        b.iter_batched(
+            || ast_module.clone(),
+            |ast_module| ditto_codegen_js::codegen(&codegen_js_config, ast_module),
+            BatchSize::LargeInput,
+        )
+    });
+    group.finish()
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(30);
+    targets = criterion_benchmark
+}
+criterion_main!(benches);

--- a/crates/ditto-benchmarks/benches/vdom-html/Attributes.ast-exports
+++ b/crates/ditto-benchmarks/benches/vdom-html/Attributes.ast-exports
@@ -1,0 +1,4935 @@
+[
+  [
+    "Attributes"
+  ],
+  {
+    "types": {
+      "Attribute": {
+        "Type": {
+          "doc_comments": [],
+          "doc_position": 0,
+          "kind": {
+            "Function": {
+              "parameters": [
+                {
+                  "Variable": 1
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "constructors": {},
+    "values": {
+      "map": {
+        "doc_comments": [],
+        "doc_position": 1,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "Constructor",
+                    "data": {
+                      "constructor_kind": {
+                        "Function": {
+                          "parameters": [
+                            {
+                              "Variable": 1
+                            }
+                          ]
+                        }
+                      },
+                      "canonical_value": {
+                        "module_name": [
+                          null,
+                          [
+                            "Attributes"
+                          ]
+                        ],
+                        "value": "Attribute"
+                      },
+                      "source_value": {
+                        "module_name": null,
+                        "value": "Attribute"
+                      }
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "type": "Variable",
+                      "data": {
+                        "variable_kind": "Type",
+                        "var": 3,
+                        "source_name": null
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "Function",
+                "data": {
+                  "parameters": [
+                    {
+                      "type": "Variable",
+                      "data": {
+                        "variable_kind": "Type",
+                        "var": 3,
+                        "source_name": null
+                      }
+                    }
+                  ],
+                  "return_type": {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": "Type",
+                      "var": 4,
+                      "source_name": null
+                    }
+                  }
+                }
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": "Type",
+                      "var": 4,
+                      "source_name": null
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "classes": {
+        "doc_comments": [],
+        "doc_position": 2,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "Call",
+                "data": {
+                  "function": {
+                    "type": "PrimConstructor",
+                    "data": "Array"
+                  },
+                  "arguments": [
+                    {
+                      "type": "PrimConstructor",
+                      "data": "String"
+                    }
+                  ]
+                }
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "id": {
+        "doc_comments": [],
+        "doc_position": 3,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "title": {
+        "doc_comments": [],
+        "doc_position": 4,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "hidden": {
+        "doc_comments": [],
+        "doc_position": 5,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "type_": {
+        "doc_comments": [],
+        "doc_position": 6,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "value": {
+        "doc_comments": [],
+        "doc_position": 7,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "checked": {
+        "doc_comments": [],
+        "doc_position": 8,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "placeholder": {
+        "doc_comments": [],
+        "doc_position": 9,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "selected": {
+        "doc_comments": [],
+        "doc_position": 10,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "accept": {
+        "doc_comments": [],
+        "doc_position": 11,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "acceptCharset": {
+        "doc_comments": [],
+        "doc_position": 12,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "action": {
+        "doc_comments": [],
+        "doc_position": 13,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "autocomplete": {
+        "doc_comments": [],
+        "doc_position": 14,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "autofocus": {
+        "doc_comments": [],
+        "doc_position": 15,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "disabled": {
+        "doc_comments": [],
+        "doc_position": 16,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "enctype": {
+        "doc_comments": [],
+        "doc_position": 17,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "list": {
+        "doc_comments": [],
+        "doc_position": 18,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "maxlength": {
+        "doc_comments": [],
+        "doc_position": 19,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Int"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "minlength": {
+        "doc_comments": [],
+        "doc_position": 20,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Int"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "method": {
+        "doc_comments": [],
+        "doc_position": 21,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "multiple": {
+        "doc_comments": [],
+        "doc_position": 22,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "name": {
+        "doc_comments": [],
+        "doc_position": 23,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "novalidate": {
+        "doc_comments": [],
+        "doc_position": 24,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "pattern": {
+        "doc_comments": [],
+        "doc_position": 25,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "readonly": {
+        "doc_comments": [],
+        "doc_position": 26,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "required": {
+        "doc_comments": [],
+        "doc_position": 27,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "size": {
+        "doc_comments": [],
+        "doc_position": 28,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Int"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "for": {
+        "doc_comments": [],
+        "doc_position": 29,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "form": {
+        "doc_comments": [],
+        "doc_position": 30,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "max": {
+        "doc_comments": [],
+        "doc_position": 31,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "min": {
+        "doc_comments": [],
+        "doc_position": 32,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "step": {
+        "doc_comments": [],
+        "doc_position": 33,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "cols": {
+        "doc_comments": [],
+        "doc_position": 34,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Int"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "rows": {
+        "doc_comments": [],
+        "doc_position": 35,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Int"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "wrap": {
+        "doc_comments": [],
+        "doc_position": 36,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "href": {
+        "doc_comments": [],
+        "doc_position": 37,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "target": {
+        "doc_comments": [],
+        "doc_position": 38,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "download": {
+        "doc_comments": [],
+        "doc_position": 39,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "hreflang": {
+        "doc_comments": [],
+        "doc_position": 40,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "media": {
+        "doc_comments": [],
+        "doc_position": 41,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "ping": {
+        "doc_comments": [],
+        "doc_position": 42,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "rel": {
+        "doc_comments": [],
+        "doc_position": 43,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "ismap": {
+        "doc_comments": [],
+        "doc_position": 44,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "usemap": {
+        "doc_comments": [],
+        "doc_position": 45,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "shape": {
+        "doc_comments": [],
+        "doc_position": 46,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "coords": {
+        "doc_comments": [],
+        "doc_position": 47,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "src": {
+        "doc_comments": [],
+        "doc_position": 48,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "height": {
+        "doc_comments": [],
+        "doc_position": 49,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Int"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "width": {
+        "doc_comments": [],
+        "doc_position": 50,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Int"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "alt": {
+        "doc_comments": [],
+        "doc_position": 51,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "autoplay": {
+        "doc_comments": [],
+        "doc_position": 52,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "controls": {
+        "doc_comments": [],
+        "doc_position": 53,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "loop": {
+        "doc_comments": [],
+        "doc_position": 54,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "preload": {
+        "doc_comments": [],
+        "doc_position": 55,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "poster": {
+        "doc_comments": [],
+        "doc_position": 56,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "default": {
+        "doc_comments": [],
+        "doc_position": 57,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "kind": {
+        "doc_comments": [],
+        "doc_position": 58,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "srclang": {
+        "doc_comments": [],
+        "doc_position": 59,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "sandbox": {
+        "doc_comments": [],
+        "doc_position": 60,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "srcdoc": {
+        "doc_comments": [],
+        "doc_position": 61,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "reversed": {
+        "doc_comments": [],
+        "doc_position": 62,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "start": {
+        "doc_comments": [],
+        "doc_position": 63,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Int"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "align": {
+        "doc_comments": [],
+        "doc_position": 64,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "colspan": {
+        "doc_comments": [],
+        "doc_position": 65,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Int"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "rowspan": {
+        "doc_comments": [],
+        "doc_position": 66,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Int"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "headers": {
+        "doc_comments": [],
+        "doc_position": 67,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "scope": {
+        "doc_comments": [],
+        "doc_position": 68,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "accesskey": {
+        "doc_comments": [],
+        "doc_position": 69,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "contenteditable": {
+        "doc_comments": [],
+        "doc_position": 70,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "contextmenu": {
+        "doc_comments": [],
+        "doc_position": 71,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "dir": {
+        "doc_comments": [],
+        "doc_position": 72,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "draggable": {
+        "doc_comments": [],
+        "doc_position": 73,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "dropzone": {
+        "doc_comments": [],
+        "doc_position": 74,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "itemprop": {
+        "doc_comments": [],
+        "doc_position": 75,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "lang": {
+        "doc_comments": [],
+        "doc_position": 76,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "spellcheck": {
+        "doc_comments": [],
+        "doc_position": 77,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Bool"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "tabindex": {
+        "doc_comments": [],
+        "doc_position": 78,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "Int"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "cite": {
+        "doc_comments": [],
+        "doc_position": 79,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "datetime": {
+        "doc_comments": [],
+        "doc_position": 80,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "pubdate": {
+        "doc_comments": [],
+        "doc_position": 81,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "manifest": {
+        "doc_comments": [],
+        "doc_position": 82,
+        "value_type": {
+          "type": "Function",
+          "data": {
+            "parameters": [
+              {
+                "type": "PrimConstructor",
+                "data": "String"
+              }
+            ],
+            "return_type": {
+              "type": "Call",
+              "data": {
+                "function": {
+                  "type": "Constructor",
+                  "data": {
+                    "constructor_kind": {
+                      "Function": {
+                        "parameters": [
+                          {
+                            "Variable": 1
+                          }
+                        ]
+                      }
+                    },
+                    "canonical_value": {
+                      "module_name": [
+                        null,
+                        [
+                          "Attributes"
+                        ]
+                      ],
+                      "value": "Attribute"
+                    },
+                    "source_value": {
+                      "module_name": null,
+                      "value": "Attribute"
+                    }
+                  }
+                },
+                "arguments": [
+                  {
+                    "type": "Variable",
+                    "data": {
+                      "variable_kind": {
+                        "Variable": 1
+                      },
+                      "var": 0,
+                      "source_name": "event"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+]

--- a/crates/ditto-benchmarks/benches/vdom-html/source.ditto
+++ b/crates/ditto-benchmarks/benches/vdom-html/source.ditto
@@ -1,0 +1,450 @@
+module Html exports (
+    Html,
+    Attributes,
+    Children,
+    text,
+    empty,
+    node,
+    map,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    div,
+    p,
+    hr,
+    pre,
+    blockquote,
+    span,
+    a,
+    code,
+    em,
+    strong,
+    i,
+    b,
+    u,
+    sub,
+    sup,
+    br,
+    ol,
+    ul,
+    li,
+    dl,
+    dt,
+    dd,
+    img,
+    iframe,
+    canvas,
+    math,
+    form,
+    input,
+    textarea,
+    button,
+    select,
+    option,
+    section,
+    nav,
+    article,
+    aside,
+    header,
+    footer,
+    address,
+    main,
+    figure,
+    figcaption,
+    table,
+    caption,
+    colgroup,
+    col,
+    tbody,
+    thead,
+    tfoot,
+    tr,
+    td,
+    th,
+    fieldset,
+    legend,
+    label,
+    datalist,
+    optgroup,
+    output,
+    progress,
+    meter,
+    audio,
+    video,
+    source,
+    track,
+    embed,
+    object,
+    param,
+    ins,
+    del,
+    small,
+    cite,
+    dfn,
+    abbr,
+    time,
+    var,
+    samp,
+    kbd,
+    s,
+    q,
+    mark,
+    ruby,
+    rt,
+    rp,
+    bdi,
+    bdo,
+    wbr,
+    details,
+    summary,
+    menuitem,
+    menu,
+)
+
+import Attributes (
+    Attribute,
+)
+
+
+type Html(event)
+
+type alias Attributes(event) = Array(Attribute(event))
+
+type alias Children(event) = Array(Html(event))
+
+text = text_impl
+
+node = fn (
+    tag: String,
+    attrs: Attributes(event),
+    children: Children(event),
+): Html(event) -> node_impl(tag, attrs, children)
+
+map = map_impl
+
+empty = text("")
+
+h1 = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("h1", attrs, children)
+
+h2 = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("h2", attrs, children)
+
+h3 = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("h3", attrs, children)
+
+h4 = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("h4", attrs, children)
+
+h5 = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("h5", attrs, children)
+
+h6 = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("h6", attrs, children)
+
+div = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("div", attrs, children)
+
+p = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("p", attrs, children)
+
+hr = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("hr", attrs, children)
+
+pre = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("pre", attrs, children)
+
+blockquote = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("blockquote", attrs, children)
+
+span = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("span", attrs, children)
+
+a = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("a", attrs, children)
+
+code = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("code", attrs, children)
+
+em = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("em", attrs, children)
+
+strong = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("strong", attrs, children)
+
+i = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("i", attrs, children)
+
+b = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("b", attrs, children)
+
+u = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("u", attrs, children)
+
+sub = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("sub", attrs, children)
+
+sup = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("sup", attrs, children)
+
+br = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("br", attrs, children)
+
+ol = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("ol", attrs, children)
+
+ul = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("ul", attrs, children)
+
+li = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("li", attrs, children)
+
+dl = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("dl", attrs, children)
+
+dt = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("dt", attrs, children)
+
+dd = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("dd", attrs, children)
+
+img = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("img", attrs, children)
+
+iframe = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("iframe", attrs, children)
+
+canvas = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("canvas", attrs, children)
+
+math = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("math", attrs, children)
+
+form = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("form", attrs, children)
+
+input = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("input", attrs, children)
+
+textarea = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("textarea", attrs, children)
+
+button = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("button", attrs, children)
+
+select = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("select", attrs, children)
+
+option = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("option", attrs, children)
+
+section = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("section", attrs, children)
+
+nav = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("nav", attrs, children)
+
+article = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("article", attrs, children)
+
+aside = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("aside", attrs, children)
+
+header = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("header", attrs, children)
+
+footer = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("footer", attrs, children)
+
+address = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("address", attrs, children)
+
+main = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("main", attrs, children)
+
+figure = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("figure", attrs, children)
+
+figcaption = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("figcaption", attrs, children)
+
+table = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("table", attrs, children)
+
+caption = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("caption", attrs, children)
+
+colgroup = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("colgroup", attrs, children)
+
+col = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("col", attrs, children)
+
+tbody = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("tbody", attrs, children)
+
+thead = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("thead", attrs, children)
+
+tfoot = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("tfoot", attrs, children)
+
+tr = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("tr", attrs, children)
+
+td = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("td", attrs, children)
+
+th = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("th", attrs, children)
+
+fieldset = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("fieldset", attrs, children)
+
+legend = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("legend", attrs, children)
+
+label = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("label", attrs, children)
+
+datalist = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("datalist", attrs, children)
+
+optgroup = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("optgroup", attrs, children)
+
+output = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("output", attrs, children)
+
+progress = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("progress", attrs, children)
+
+meter = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("meter", attrs, children)
+
+audio = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("audio", attrs, children)
+
+video = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("video", attrs, children)
+
+source = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("source", attrs, children)
+
+track = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("track", attrs, children)
+
+embed = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("embed", attrs, children)
+
+object = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("object", attrs, children)
+
+param = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("param", attrs, children)
+
+ins = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("ins", attrs, children)
+
+del = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("del", attrs, children)
+
+small = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("small", attrs, children)
+
+cite = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("cite", attrs, children)
+
+dfn = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("dfn", attrs, children)
+
+abbr = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("abbr", attrs, children)
+
+time = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("time", attrs, children)
+
+var = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("var", attrs, children)
+
+samp = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("samp", attrs, children)
+
+kbd = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("kbd", attrs, children)
+
+s = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("s", attrs, children)
+
+q = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("q", attrs, children)
+
+mark = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("mark", attrs, children)
+
+ruby = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("ruby", attrs, children)
+
+rt = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("rt", attrs, children)
+
+rp = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("rp", attrs, children)
+
+bdi = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("bdi", attrs, children)
+
+bdo = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("bdo", attrs, children)
+
+wbr = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("wbr", attrs, children)
+
+details = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("details", attrs, children)
+
+summary = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("summary", attrs, children)
+
+menuitem = fn (attrs: Attributes(event), children: Children(event)): Html(
+    event,
+) -> node("menuitem", attrs, children)
+
+menu = fn (attrs: Attributes(event), children: Children(event)): Html(event) ->
+    node("menu", attrs, children)
+
+foreign node_impl: (String, Attributes(event), Children(event)) -> Html(event)
+
+foreign text_impl: (String) -> Html(event)
+
+foreign map_impl: (Html(a), (a) -> b) -> Html(b)

--- a/crates/ditto-benchmarks/src/lib.rs
+++ b/crates/ditto-benchmarks/src/lib.rs
@@ -1,0 +1,1 @@
+// nothing to see here, go look at `benches`

--- a/shell.nix
+++ b/shell.nix
@@ -85,6 +85,7 @@ pkgs.mkShell {
     pkgs.cargo-udeps
     pkgs.cargo-audit
     pkgs.cargo-outdated
+    pkgs.cargo-criterion
     cargo-benchcmp
     pkgs.inferno
 


### PR DESCRIPTION
Time to start thinking about making `ditto` fast, methinks.

This first batch of benchmarks are guided by #217, which identified some suspicious outliers when profiling a cold build of https://github.com/ditto-lang/playground.

Specifically, this PR adds benchmarks for parsing, checking, code-generating, and formatting for:

- [x] https://github.com/ditto-lang/vdom/blob/893a9ededeeecfa980463c1c7651762030e1c878/ditto-src/Html.ditto